### PR TITLE
Add image search modal to simple pet gallery

### DIFF
--- a/simple.html
+++ b/simple.html
@@ -9,22 +9,80 @@
       padding: 20px;
       background-color: #f4f4f4;
     }
+
+    #search-bar {
+      margin-bottom: 20px;
+    }
+
     #pet-grid {
-      display: flex;
-      flex-wrap: wrap;
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      grid-auto-rows: 200px;
       gap: 10px;
     }
+
     #pet-grid img {
-      width: 200px;
-      height: 200px;
+      width: 100%;
+      height: 100%;
       object-fit: cover;
       border: 1px solid #ccc;
       border-radius: 4px;
       cursor: move;
     }
+
+    .modal {
+      display: none;
+      position: fixed;
+      z-index: 1;
+      padding-top: 60px;
+      left: 0;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      overflow: auto;
+      background-color: rgba(0,0,0,0.4);
+    }
+
+    .modal-content {
+      background-color: #fefefe;
+      margin: auto;
+      padding: 20px;
+      border: 1px solid #888;
+      width: 80%;
+    }
+
+    .close {
+      color: #aaa;
+      float: right;
+      font-size: 28px;
+      font-weight: bold;
+      cursor: pointer;
+    }
+
+    #results {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    #results img {
+      width: 150px;
+      height: 150px;
+      object-fit: cover;
+      border: 2px solid transparent;
+      cursor: pointer;
+    }
+
+    #results img.selected {
+      border-color: #007BFF;
+    }
   </style>
 </head>
 <body>
+  <div id="search-bar">
+    <input type="text" id="search-input" placeholder="Search for images">
+    <button id="search-button">Search</button>
+  </div>
   <h1>Drag to Reorder Pets</h1>
   <div id="pet-grid">
     <img src="https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/dog.jpg" draggable="true" alt="Dog">
@@ -32,9 +90,78 @@
     <img src="https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/dog.jpg" draggable="true" alt="Dog 2">
     <img src="https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/lion_drawing.png" draggable="true" alt="Lion 2">
   </div>
+
+  <div id="result-modal" class="modal">
+    <div class="modal-content">
+      <span class="close" id="modal-close">&times;</span>
+      <div id="results"></div>
+      <button id="add-button">Add Selected</button>
+    </div>
+  </div>
   <script>
+    // Replace with your Google Custom Search API key and CX
+    const API_KEY = 'YOUR_API_KEY';
+    const CX = 'YOUR_SEARCH_ENGINE_ID';
+
     const grid = document.getElementById('pet-grid');
+    const searchBtn = document.getElementById('search-button');
+    const searchInput = document.getElementById('search-input');
+    const modal = document.getElementById('result-modal');
+    const closeModal = document.getElementById('modal-close');
+    const resultsDiv = document.getElementById('results');
+    const addButton = document.getElementById('add-button');
     let dragged;
+
+    async function searchImages(query) {
+      const url = `https://www.googleapis.com/customsearch/v1?q=${encodeURIComponent(query)}&searchType=image&num=4&key=${API_KEY}&cx=${CX}`;
+      const response = await fetch(url);
+      const data = await response.json();
+      return (data.items || []).map(item => item.link);
+    }
+
+    searchBtn.addEventListener('click', async () => {
+      const query = searchInput.value.trim();
+      if (!query) return;
+      const links = await searchImages(query);
+      resultsDiv.innerHTML = '';
+      links.forEach(link => {
+        const img = document.createElement('img');
+        img.src = link;
+        img.addEventListener('click', () => {
+          img.classList.toggle('selected');
+        });
+        resultsDiv.appendChild(img);
+      });
+      modal.style.display = 'block';
+    });
+
+    searchInput.addEventListener('keyup', (e) => {
+      if (e.key === 'Enter') {
+        searchBtn.click();
+      }
+    });
+
+    closeModal.addEventListener('click', () => {
+      modal.style.display = 'none';
+    });
+
+    addButton.addEventListener('click', () => {
+      const selected = resultsDiv.querySelectorAll('img.selected');
+      selected.forEach(sel => {
+        const newImg = document.createElement('img');
+        newImg.src = sel.src;
+        newImg.draggable = true;
+        grid.appendChild(newImg);
+      });
+      modal.style.display = 'none';
+      resultsDiv.innerHTML = '';
+    });
+
+    window.addEventListener('click', (e) => {
+      if (e.target === modal) {
+        modal.style.display = 'none';
+      }
+    });
 
     grid.addEventListener('dragstart', (e) => {
       if (e.target.tagName === 'IMG') {


### PR DESCRIPTION
## Summary
- implement 5-column grid layout for pet images
- add search bar and modal to search Google images (requires API key)
- allow selecting search results to add images to grid
- maintain drag-and-drop reordering

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6863b52d54188331bc8fec21f8f521c3