### PR TITLE
Enable shooting in Fruit Drop

### DIFF
--- a/drop-game.html
+++ b/drop-game.html
@@ -41,21 +41,23 @@
     let basketX = (canvas.width - basketWidth) / 2;
     const basketY = canvas.height - basketHeight - 10;
 
-    let rightPressed = false;
-    let leftPressed = false;
-    document.addEventListener('keydown', e => {
-      if (e.key === 'ArrowRight' || e.key === 'd') rightPressed = true;
-      if (e.key === 'ArrowLeft' || e.key === 'a') leftPressed = true;
-    });
-    document.addEventListener('keyup', e => {
-      if (e.key === 'ArrowRight' || e.key === 'd') rightPressed = false;
-      if (e.key === 'ArrowLeft' || e.key === 'a') leftPressed = false;
-    });
+      let rightPressed = false;
+      let leftPressed = false;
+      document.addEventListener('keydown', e => {
+        if (e.key === 'ArrowRight' || e.key === 'd') rightPressed = true;
+        if (e.key === 'ArrowLeft' || e.key === 'a') leftPressed = true;
+        if (e.key === 'ArrowUp' || e.key === 'w') shoot();
+      });
+      document.addEventListener('keyup', e => {
+        if (e.key === 'ArrowRight' || e.key === 'd') rightPressed = false;
+        if (e.key === 'ArrowLeft' || e.key === 'a') leftPressed = false;
+      });
 
-    const items = [];
-    let score = 0;
-    let gameOver = false;
-    let itemSpeed = 2; // falling speed for items
+      const items = [];
+      const bullets = [];
+      let score = 0;
+      let gameOver = false;
+      let itemSpeed = 2; // falling speed for items
 
     function spawnItem() {
       const types = ['fruit', 'fruit', 'fruit', 'bomb']; // more fruits than bombs
@@ -63,6 +65,41 @@
       const radius = 15;
       const x = Math.random() * (canvas.width - radius * 2) + radius;
       items.push({ x, y: -radius, radius, type });
+    }
+
+    function shoot() {
+      if (score <= 0) return;
+      bullets.push({ x: basketX + basketWidth / 2, y: basketY, radius: 5 });
+      score--;
+      document.getElementById('score').textContent = 'Score: ' + score;
+    }
+
+    function drawBullet(bullet) {
+      ctx.fillStyle = '#fff';
+      ctx.beginPath();
+      ctx.arc(bullet.x, bullet.y, bullet.radius, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    function updateBullets() {
+      for (let i = bullets.length - 1; i >= 0; i--) {
+        const b = bullets[i];
+        b.y -= 7;
+        if (b.y + b.radius < 0) {
+          bullets.splice(i, 1);
+          continue;
+        }
+        for (let j = items.length - 1; j >= 0; j--) {
+          const item = items[j];
+          const dx = b.x - item.x;
+          const dy = b.y - item.y;
+          if (Math.sqrt(dx * dx + dy * dy) < b.radius + item.radius) {
+            items.splice(j, 1);
+            bullets.splice(i, 1);
+            break;
+          }
+        }
+      }
     }
 
     function drawBasket() {
@@ -109,6 +146,7 @@
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       drawBasket();
       items.forEach(drawItem);
+      bullets.forEach(drawBullet);
     }
 
     function step() {
@@ -116,6 +154,7 @@
       if (rightPressed && basketX < canvas.width - basketWidth) basketX += 5;
       if (leftPressed && basketX > 0) basketX -= 5;
       if (Math.random() < 0.03) spawnItem();
+      updateBullets();
       updateItems();
       draw();
       requestAnimationFrame(step);


### PR DESCRIPTION
## Summary
- allow a player to press up or `w` to shoot
- subtract 1 point per shot if score is available
- draw and update bullets that destroy items on impact

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68644c4d69c88331bf5d22ef0e9d6044