### PR TITLE
Scale down drop game elements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,6 @@
 This repository contains a collection of small arcade games. All ambiguous instructions should be interpreted as referring to these games and the arcade overall.
 
 ## Current Game Under Construction
-- joust
+- drop game
 
 If a request does not specify a particular game, assume it applies to the game listed above. When a request specifically names another game, work on that game and update this section with its name.

--- a/drop-game.html
+++ b/drop-game.html
@@ -79,7 +79,7 @@
   <div id="sidebar-placeholder"></div>
   <div id="game-container">
     <h1>Fruit Drop</h1>
-    <canvas id="gameCanvas" width="600" height="900"></canvas>
+    <canvas id="gameCanvas" width="600" height="630"></canvas>
     <div id="score">Score: 0</div>
     <div id="message"></div>
   </div>
@@ -111,9 +111,9 @@
     let speedMultiplier = 2; // global speed multiplier
 
     const sizeConfigs = {
-      small:  { radius: 15, speed: 3,   points: 3 },
-      medium: { radius: 22.5, speed: 2,   points: 2 },
-      large:  { radius: 30, speed: 1.5, points: 1 }
+      small:  { radius: 10.5, speed: 3,   points: 3 },
+      medium: { radius: 15.75, speed: 2,   points: 2 },
+      large:  { radius: 21, speed: 1.5, points: 1 }
     };
 
     const images = {
@@ -141,7 +141,7 @@
         const x = Math.random() * (canvas.width - cfg.radius * 2) + cfg.radius;
         items.push({ x, y: -cfg.radius, radius: cfg.radius, type, speed: cfg.speed, points: cfg.points, vx, img: images[size] });
       } else {
-        const radius = 22.5;
+        const radius = 15.75;
         const x = Math.random() * (canvas.width - radius * 2) + radius;
         items.push({ x, y: -radius, radius, type, speed: 2, points: 0, vx, img: images.bomb });
       }


### PR DESCRIPTION
## Summary
- shrink the playfield height and fruit sizes by 30%
- adjust bomb radius
- update repo guidance to note that the drop game is being modified

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68681e796f14833187f1a4fc6115066d