### PR TITLE
Improve joust collisions and jumping

### DIFF
--- a/joust.html
+++ b/joust.html
@@ -181,8 +181,10 @@
         if(this.x > p.x-BIRD_RADIUS && this.x < p.x+p.width+BIRD_RADIUS &&
            this.y+BIRD_RADIUS > p.y && this.y-BIRD_RADIUS < p.y+p.height){
           if(prevY + BIRD_RADIUS <= p.y){
-            this.y = p.y - BIRD_RADIUS;
-            this.vy = 0; onGround=true;
+            if(this.vy >= 0){
+              this.y = p.y - BIRD_RADIUS;
+              this.vy = 0; onGround=true;
+            }
           } else if(prevY - BIRD_RADIUS >= p.y + p.height){
             this.y = p.y + p.height + BIRD_RADIUS;
             if(this.vy<0) this.vy=0;
@@ -204,6 +206,7 @@
   let lives = 3;
   let stage = 1;
   let enemies = [];
+  let effects = [];
   let totalToSpawn = 6;
   let spawned = 0;
   let nextSpawn = 0;
@@ -228,31 +231,64 @@
     player = new Knight(canvas.width/2,GROUND_Y-BIRD_RADIUS,true);
   }
 
+  function createEffect(x,y){
+    effects.push({x,y,r:0,alpha:1});
+  }
+
+  function updateEffects(){
+    for(let i=effects.length-1;i>=0;i--){
+      const ef=effects[i];
+      ef.r+=2;
+      ef.alpha-=0.04;
+      if(ef.alpha<=0) effects.splice(i,1);
+    }
+  }
+
+  function drawEffects(){
+    for(const ef of effects){
+      ctx.save();
+      ctx.globalAlpha=ef.alpha;
+      ctx.strokeStyle='yellow';
+      ctx.lineWidth=2;
+      ctx.beginPath();
+      ctx.arc(ef.x,ef.y,ef.r,0,Math.PI*2);
+      ctx.stroke();
+      ctx.restore();
+    }
+  }
+
   function checkCollisions(){
-    for(let i=enemies.length-1;i>=0;i--){
-      const e=enemies[i];
-      const dx=e.x-player.x;
-      const dy=e.y-player.y;
-      const dist=Math.sqrt(dx*dx+dy*dy);
-      if(dist < BIRD_RADIUS*2){
-        const diff = e.y - player.y;
-        const thresh = 0.05*canvas.height;
-        if(diff > thresh){ // enemy higher
-          lives--;
-          if(lives<=0){
-            document.getElementById('message').textContent='Game Over';
-            running=false;
+    const all=[player,...enemies];
+    for(let i=0;i<all.length;i++){
+      for(let j=i+1;j<all.length;j++){
+        const a=all[i], b=all[j];
+        if(!a.alive || !b.alive) continue;
+        const dx=a.x-b.x;
+        const dy=a.y-b.y;
+        if(Math.hypot(dx,dy) < BIRD_RADIUS*2){
+          const diff=a.y-b.y;
+          if(Math.abs(diff) > 2){
+            const lower = diff>0 ? a : b;
+            const higher = diff>0 ? b : a;
+            if(lower.isPlayer){
+              lives--;
+              if(lives<=0){
+                document.getElementById('message').textContent='Game Over';
+                running=false;
+              } else {
+                resetPlayer();
+              }
+            }
+            if(lower!==player){
+              const idx=enemies.indexOf(lower);
+              if(idx>=0) enemies.splice(idx,1);
+            }
+            createEffect(lower.x,lower.y);
           } else {
-            resetPlayer();
+            const tempVy=a.vy;
+            a.vy=-Math.abs(b.vy);
+            b.vy=-Math.abs(tempVy);
           }
-          enemies.splice(i,1);
-        } else if(diff < -thresh){ // player higher
-          enemies.splice(i,1);
-        } else {
-          // bounce
-          const tempVy = player.vy;
-          player.vy = -Math.abs(e.vy);
-          e.vy = -Math.abs(tempVy);
         }
       }
     }
@@ -269,6 +305,7 @@
     }
     player.update();
     enemies.forEach(e=>e.update());
+    updateEffects();
     checkCollisions();
     if(spawned>=totalToSpawn && enemies.length===0){
       stage++; lives=3; resetPlayer(); startStage();
@@ -298,6 +335,7 @@
     }
     player.draw();
     enemies.forEach(e=>e.draw());
+    drawEffects();
   }
 
   function loop(){


### PR DESCRIPTION
## Summary
- fix platform collision logic so the player can take off
- make knights destroy each other when one is more than two pixels lower
- add explosion effect when a knight is destroyed
- update game loops to handle new effects

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_68682385530483318c313026353e9889