### PR TITLE
Add dense cherry and grape waves to drop game

### DIFF
--- a/drop-game.html
+++ b/drop-game.html
@@ -109,6 +109,8 @@
     let score = 0;
     let gameOver = false;
     let speedMultiplier = 2; // global speed multiplier
+    let cherryWaveTriggered = false;
+    let grapeWaveTriggered = false;
 
     const sizeConfigs = {
       small:  { radius: 10.5, speed: 3,   points: 3 },
@@ -120,12 +122,14 @@
       small: new Image(),
       medium: new Image(),
       large: new Image(),
-      bomb: new Image()
+      bomb: new Image(),
+      cherry: new Image()
     };
     images.small.src = 'images/grapes.svg';
     images.medium.src = 'images/apple.svg';
     images.large.src = 'images/watermelon.svg';
     images.bomb.src = 'images/cherry-bomb.svg';
+    images.cherry.src = 'images/cherry.svg';
 
 
     function spawnItem() {
@@ -144,6 +148,29 @@
         const radius = 15.75;
         const x = Math.random() * (canvas.width - radius * 2) + radius;
         items.push({ x, y: -radius, radius, type, speed: 2, points: 0, vx, img: images.bomb });
+      }
+    }
+
+    function spawnCherryWave() {
+      const cfg = sizeConfigs.small;
+      const spacing = cfg.radius * 2;
+      for (let x = cfg.radius; x < canvas.width; x += spacing) {
+        items.push({ x, y: -cfg.radius, radius: cfg.radius, type: 'fruit', speed: cfg.speed, points: cfg.points, vx: 0, img: images.cherry });
+      }
+    }
+
+    function spawnGrapeWave() {
+      const cfg = sizeConfigs.small;
+      const spacing = cfg.radius * 2;
+      const cols = Math.floor(canvas.width / spacing);
+      let count = 0;
+      for (let row = 0; count < 100; row++) {
+        const y = -cfg.radius - row * spacing;
+        for (let col = 0; col < cols && count < 100; col++) {
+          const x = cfg.radius + col * spacing;
+          items.push({ x, y, radius: cfg.radius, type: 'fruit', speed: cfg.speed, points: cfg.points, vx: 0, img: images.small });
+          count++;
+        }
       }
     }
 
@@ -246,6 +273,16 @@
       if (Math.random() < 0.03) spawnItem();
       updateBullets();
       updateItems();
+      if (!cherryWaveTriggered && score >= 50) {
+        cherryWaveTriggered = true;
+        spawnCherryWave();
+        setTimeout(() => {
+          if (!grapeWaveTriggered) {
+            grapeWaveTriggered = true;
+            spawnGrapeWave();
+          }
+        }, 3000);
+      }
       draw();
       requestAnimationFrame(step);
     }

--- a/images/cherry.svg
+++ b/images/cherry.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="24" cy="40" r="10" fill="#d32f2f" />
+  <circle cx="40" cy="40" r="10" fill="#d32f2f" />
+  <path d="M24 32 C24 28 26 26 28 26" stroke="#6d4c41" stroke-width="3" fill="none"/>
+  <path d="M40 32 C40 28 38 26 36 26" stroke="#6d4c41" stroke-width="3" fill="none"/>
+  <path d="M32 26 L32 14" stroke="#6d4c41" stroke-width="3"/>
+</svg>


### PR DESCRIPTION
## Summary
- create a new cherry image
- trigger a dense cherry wave once the player reaches 50 points
- follow the cherry wave with 100 grapes falling in a grid

## Testing
- `node test_egg.js` *(fails: no display or not relevant)*

------
https://chatgpt.com/codex/tasks/task_e_6868640b9cb08331bfa409cc29f20b1e