### PR TITLE
Add scoring to Flappy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,6 @@
 This repository contains a collection of small arcade games. All ambiguous instructions should be interpreted as referring to these games and the arcade overall.
 
 ## Current Game Under Construction
-- pinball game
+- flappy game
 
 If a request does not specify a particular game, assume it applies to the game listed above. When a request specifically names another game, work on that game and update this section with its name.

--- a/flappy.html
+++ b/flappy.html
@@ -93,6 +93,7 @@
     score = 0;
     running = true;
     document.getElementById('message').textContent = '';
+    document.getElementById('score').textContent = `Score: ${score}`;
     spawnPipe();
   }
 
@@ -100,7 +101,7 @@
   function spawnPipe() {
     const gap = currentPipeGap;
     const gapY = 80 + Math.random()*(canvas.height - gap - 160);
-    pipes.push({ x: canvas.width, gapY, gap });
+    pipes.push({ x: canvas.width, gapY, gap, passed:false });
     if(Math.random() < 0.8) {
       coins.push({ x: canvas.width + pipeWidth/2, y: gapY + gap/2, collected:false });
     }
@@ -140,6 +141,11 @@
 
     for(const p of pipes) {
       p.x -= pipeSpeed;
+      if(!p.passed && p.x + pipeWidth < bird.x - bird.r) {
+        p.passed = true;
+        score += 5;
+        document.getElementById('score').textContent = `Score: ${score}`;
+      }
     }
     while(pipes.length && pipes[0].x + pipeWidth < -50) pipes.shift();
 
@@ -151,7 +157,7 @@
     for(const c of coins) {
       if(!c.collected && Math.hypot(bird.x - c.x, bird.y - c.y) < bird.r + coinRadius) {
         c.collected = true;
-        score += 1;
+        score += 25;
         document.getElementById('score').textContent = `Score: ${score}`;
       }
     }


### PR DESCRIPTION
## Summary
- update repo guidance to reflect Flappy as the current game
- add score display reset when the game starts
- award points when passing pipes or collecting coins in Flappy

## Testing
- `node test_egg.js` *(fails: Egg is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687d20b0e85c8331a83fc8ccbbe107bf