### PR TITLE
Fix flappy sidebar style

### DIFF
--- a/flappy.html
+++ b/flappy.html
@@ -19,6 +19,22 @@
       padding: 20px;
       box-shadow: 2px 0 8px rgba(0,0,0,0.2);
     }
+    #sidebar ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    #sidebar li {
+      margin: 15px 0;
+    }
+    #sidebar a {
+      color: #fff;
+      text-decoration: none;
+      transition: color 0.3s;
+    }
+    #sidebar a:hover {
+      color: #ffea00;
+    }
     #game-container {
       flex: 1;
       display: flex;


### PR DESCRIPTION
## Summary
- style sidebar links in **flappy.html** so they match the menus on other pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d237f42fc833193af4628bac1f89e