### PR TITLE
Add initial flap to start in Flappy

### DIFF
--- a/flappy.html
+++ b/flappy.html
@@ -95,6 +95,8 @@
     document.getElementById('message').textContent = '';
     document.getElementById('score').textContent = `Score: ${score}`;
     spawnPipe();
+    // give the player a moment by starting with an initial flap
+    bird.vy = flapPower;
   }
 
   let spawnTimer = 0;


### PR DESCRIPTION
## Summary
- tweak Flappy game setup so the bird takes an automatic flap when a new game starts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d23a2ddc48331aaf4a28ce2895390