### PR TITLE
Fix ball launch in pinball

### DIFF
--- a/pinball.html
+++ b/pinball.html
@@ -340,6 +340,8 @@
           ball.inLaunch = false;
           ball.x = launchLane.x - ballRadius;
           ball.vx = -2;
+          // plunger returns to starting position after launch
+          plunger.power = 0;
         }
         return;
       }
@@ -522,7 +524,7 @@
         if(ball.inLaunch){
           ball.vy = -plunger.power * launchScale;
         }
-        plunger.power = 0;
+        // keep plunger extended until ball leaves the launch lane
       }
     });
 


### PR DESCRIPTION
## Summary
- keep plunger extended while the ball is still in the launch lane
- reset the plunger once the ball exits the lane

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687d27de1a088331ba45eb22ea95d3c9