### PR TITLE
Add SVG graphics and levels to Burger Time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository contains a collection of small arcade games. All ambiguous instructions should be interpreted as referring to these games and the arcade overall.
 
 ## Current Game Under Construction
-- tetris game
+- burger time game
 
 
 If a request does not specify a particular game, assume it applies to the game listed above. When a request specifically names another game, work on that game and update this section with its name.

--- a/burger.html
+++ b/burger.html
@@ -41,6 +41,13 @@
   const canvas = document.getElementById('gameCanvas');
   const ctx = canvas.getContext('2d');
 
+  const images = {};
+  ['cook','enemy','burger_top','burger_lettuce','burger_patty','burger_bottom'].forEach(name=>{
+    const img = new Image();
+    img.src = `images/${name}.svg`;
+    images[name] = img;
+  });
+
   // tile and level setup
   const COLS = 20;
   const ROWS = 15;
@@ -48,27 +55,62 @@
   canvas.width = COLS * TILE;
   canvas.height = ROWS * TILE;
 
-  const floors = [3,7,11,15]; // grid rows for platforms (from top)
-  const ladders = [
-    {x:4, top:3, bottom:15},
-    {x:10, top:3, bottom:15},
-    {x:16, top:3, bottom:15}
+  const levels = [
+    {
+      floors: [3,7,11,15],
+      ladders: [
+        {x:4, top:3, bottom:15},
+        {x:10, top:3, bottom:15},
+        {x:16, top:3, bottom:15}
+      ],
+      burgerX: [6,10,14]
+    },
+    {
+      floors: [3,6,9,12],
+      ladders: [
+        {x:5, top:3, bottom:12},
+        {x:11, top:3, bottom:12},
+        {x:17, top:3, bottom:12}
+      ],
+      burgerX: [4,10,16]
+    }
   ];
 
-  const burgerX = [6,10,14];
+  let levelIndex = 0;
+  let floors = [];
+  let ladders = [];
+  let burgerX = [];
   const pieces = [];
   const types = ['top','lettuce','patty','bottom'];
-  for(let col of burgerX){
-    for(let i=0;i<types.length;i++){
-      pieces.push({x:col, y:floors[i], type:types[i], falling:false});
+
+  function loadLevel(index){
+    levelIndex = index % levels.length;
+    const level = levels[levelIndex];
+    floors = level.floors.slice();
+    ladders = level.ladders.map(l=>Object.assign({},l));
+    burgerX = level.burgerX.slice();
+    pieces.length = 0;
+    for(let col of burgerX){
+      for(let i=0;i<types.length;i++){
+        pieces.push({x:col, y:floors[i], type:types[i], falling:false});
+      }
     }
+    player.x = burgerX[0];
+    player.y = floors[0];
+    player.pepper = 3;
+    enemies = [ {x:18, y:floors[2], vx:-0.02, vy:0, width:1, height:1, stunned:0} ];
+    gameOver = false;
+    win = false;
+    document.getElementById('message').textContent='';
   }
 
-  const player = {x:burgerX[0], y:floors[0], vx:0, vy:0, dir:1, pepper:3, width:1, height:1};
-  let enemies = [ {x:18, y:floors[2], vx:-0.02, vy:0, width:1, height:1, stunned:0} ];
+  const player = {x:0, y:0, vx:0, vy:0, dir:1, pepper:3, width:1, height:1};
+  let enemies = [];
 
   let gameOver=false;
   let win=false;
+
+  loadLevel(0);
 
   function isOnFloor(obj){
     return floors.includes(obj.y);
@@ -129,7 +171,10 @@
 
     if(pieces.every(p=>p.complete)){
       win=true;
-      document.getElementById('message').textContent='You Win!';
+      document.getElementById('message').textContent='Level Complete!';
+      setTimeout(()=>{
+        loadLevel(levelIndex + 1);
+      }, 1500);
     }
 
     document.getElementById('info').textContent=`Pepper: ${player.pepper}`;
@@ -169,25 +214,21 @@
     // pieces
     for(const p of pieces){
       if(p.complete) continue;
-      switch(p.type){
-        case 'top': ctx.fillStyle='#d2691e'; break;
-        case 'lettuce': ctx.fillStyle='#8fbc8f'; break;
-        case 'patty': ctx.fillStyle='#8b4513'; break;
-        case 'bottom': ctx.fillStyle='#cd853f'; break;
-      }
-      ctx.fillRect(p.x,p.y-1,2,1);
+      const img = images[`burger_${p.type}`];
+      if(img.complete) ctx.drawImage(img, p.x, p.y-1, 2, 1);
     }
     // player
-    ctx.fillStyle='white';
-    ctx.fillRect(player.x,player.y-1,1,1);
+    const pc = images.cook;
+    if(pc.complete) ctx.drawImage(pc, player.x, player.y-1, 1, 1);
     // enemies
-    ctx.fillStyle='red';
+    const enemyImg = images.enemy;
     for(const e of enemies){
-      ctx.fillRect(e.x,e.y-1,1,1);
+      const img = enemyImg;
+      if(img.complete) ctx.drawImage(img, e.x, e.y-1, 1, 1);
       if(e.stunned>0){
-        ctx.fillStyle='blue';
-        ctx.fillRect(e.x,e.y-1,1,1);
-        ctx.fillStyle='red';
+        ctx.globalAlpha = 0.5;
+        if(img.complete) ctx.drawImage(img, e.x, e.y-1, 1, 1);
+        ctx.globalAlpha = 1;
       }
     }
     ctx.restore();

--- a/images/burger_bottom.svg
+++ b/images/burger_bottom.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" fill="none"/>
+  <ellipse cx="16" cy="16" rx="12" ry="3" fill="#d2b48c"/>
+  <rect x="4" y="16" width="24" height="4" fill="#f4a460"/>
+</svg>

--- a/images/burger_lettuce.svg
+++ b/images/burger_lettuce.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" fill="none"/>
+  <path d="M4 16 Q8 12 12 16 T20 16 T28 16" fill="#8fbc8f" stroke="#3e8e41"/>
+</svg>

--- a/images/burger_patty.svg
+++ b/images/burger_patty.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" fill="none"/>
+  <rect x="4" y="14" width="24" height="6" rx="2" fill="#8b4513"/>
+</svg>

--- a/images/burger_top.svg
+++ b/images/burger_top.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" fill="none"/>
+  <path d="M4 16 Q16 4 28 16" fill="#f4a460" stroke="#d2691e"/>
+  <ellipse cx="16" cy="14" rx="12" ry="3" fill="#d2b48c"/>
+</svg>

--- a/images/cook.svg
+++ b/images/cook.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" fill="none"/>
+  <rect x="12" y="18" width="8" height="10" fill="#fff8e1" stroke="#795548" stroke-width="1"/>
+  <rect x="14" y="10" width="4" height="8" fill="#ffcc80"/>
+  <rect x="13" y="8" width="6" height="3" fill="#fff"/>
+  <circle cx="16" cy="6" r="2" fill="#fff"/>
+</svg>

--- a/images/enemy.svg
+++ b/images/enemy.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" fill="none"/>
+  <rect x="8" y="18" width="16" height="10" fill="#ff5252" stroke="#b71c1c" stroke-width="1"/>
+  <circle cx="12" cy="12" r="2" fill="#fff"/>
+  <circle cx="20" cy="12" r="2" fill="#fff"/>
+</svg>


### PR DESCRIPTION
## Summary
- update AGENTS to mention Burger Time
- add SVG artwork for cook, enemies, and burger pieces
- implement multiple levels and next level message
- load SVG images in Burger Time and draw them on canvas

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_687e137ca8d48331afc47ac2b1f8b4ec