### PR TITLE
Add asteroid SVG and use it in Asteroids game

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository contains a collection of small arcade games. All ambiguous instructions should be interpreted as referring to these games and the arcade overall.
 
 ## Current Game Under Construction
-- tetris game
+- asteroids game
 
 
 If a request does not specify a particular game, assume it applies to the game listed above. When a request specifically names another game, work on that game and update this section with its name.

--- a/asteroids.html
+++ b/asteroids.html
@@ -78,6 +78,8 @@
   <script>
     const canvas = document.getElementById('gameCanvas');
     const ctx = canvas.getContext('2d');
+    const asteroidImg = new Image();
+    asteroidImg.src = 'images/asteroid.svg';
 
     const KEY = {left:false,right:false,up:false,space:false};
     document.addEventListener('keydown', e=>{
@@ -265,9 +267,13 @@
       drawExplosions();
       ctx.strokeStyle = '#fff';
       asteroids.forEach(a=>{
-        ctx.beginPath();
-        ctx.arc(a.x,a.y,a.size*10,0,Math.PI*2);
-        ctx.stroke();
+        if(asteroidImg.complete){
+          ctx.drawImage(asteroidImg, a.x - a.size*10, a.y - a.size*10, a.size*20, a.size*20);
+        } else {
+          ctx.beginPath();
+          ctx.arc(a.x,a.y,a.size*10,0,Math.PI*2);
+          ctx.stroke();
+        }
       });
       bullets.forEach(b=>{
         ctx.fillStyle = '#fff';

--- a/images/asteroid.svg
+++ b/images/asteroid.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M32 6 L42 8 L54 14 L60 28 L56 40 L44 56 L30 58 L16 54 L10 42 L8 28 L14 16 L26 8 Z" fill="#9e9e9e" stroke="#757575" stroke-width="2"/>
+</svg>


### PR DESCRIPTION
## Summary
- switch repo focus to the Asteroids game
- add new `asteroid.svg` graphic
- load and draw the SVG in `asteroids.html`

## Testing
- `node --version`
- `node test_egg.js` *(fails: Egg is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687e1423dbc0833182f19df89ab9dd9b