### PR TITLE
Enhance Burger Time visuals and movement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository contains a collection of small arcade games. All ambiguous instructions should be interpreted as referring to these games and the arcade overall.
 
 ## Current Game Under Construction
-- asteroids game
+- burger time game
 
 
 

--- a/burger.html
+++ b/burger.html
@@ -9,7 +9,7 @@
       display: flex;
       min-height: 100vh;
       overflow: hidden;
-      background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%);
+      background: linear-gradient(135deg, #ffe0b3 0%, #ffb347 100%);
       font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
       color: #fff;
     }
@@ -24,7 +24,14 @@
     #sidebar a { color:#fff; text-decoration:none; }
     #game { flex:1; display:flex; flex-direction:column; align-items:center; justify-content:flex-start; padding:20px; }
     h1 { margin-top:0; font-size:2.5em; }
-    canvas { background:#222; border:2px solid #fff; border-radius:8px; width:100%; height:auto; max-height:75vh; }
+    canvas {
+      background: linear-gradient(#d9e4f5, #a6c0e1);
+      border:2px solid #fff;
+      border-radius:8px;
+      width:100%;
+      height:auto;
+      max-height:75vh;
+    }
     #info { margin-top:10px; font-size:20px; }
     #message { margin-top:10px; font-size:24px; color:#ffeb3b; }
   </style>
@@ -113,17 +120,37 @@
   loadLevel(0);
 
   function isOnFloor(obj){
-    return floors.includes(obj.y);
+    return floors.some(f=>Math.abs(obj.y - f) < 0.1);
+  }
+
+  function isOnPiece(obj){
+    return pieces.some(p=>!p.complete && Math.abs(obj.y - (p.y-1)) < 0.1 && obj.x>=p.x && obj.x<=p.x+1);
   }
 
   function pieceAt(x,y){
     return pieces.find(p=>p.x===x && p.y===y && !p.falling);
   }
 
+  function isSupported(obj){
+    return isOnFloor(obj) || isOnPiece(obj);
+  }
+
+  function ridePieces(obj){
+    for(const p of pieces){
+      if(p.falling && obj.x>=p.x && obj.x<=p.x+1 && Math.abs(obj.y-(p.y-1))<0.1){
+        obj.y+=0.1;
+      }
+    }
+  }
+
   function update(){
     if(gameOver || win) return;
     // player movement
-    if(keys.left) player.vx=-0.1; else if(keys.right) player.vx=0.1; else player.vx=0;
+    if(isSupported(player)){
+      if(keys.left) player.vx=-0.1; else if(keys.right) player.vx=0.1; else player.vx=0;
+    } else {
+      player.vx = 0;
+    }
     player.x += player.vx;
     if(keys.up && ladderAt(Math.round(player.x), player.y)) player.y -=0.1;
     if(keys.down && ladderAt(Math.round(player.x), player.y)) player.y +=0.1;
@@ -138,24 +165,28 @@
 
     for(const p of pieces){
       if(p.falling){
-        p.y+=0.1;
-        const below = pieceAt(p.x, Math.round(p.y)+1);
+        p.y += 0.1;
+        const below = pieceAt(p.x, Math.round(p.y) + 1);
         if(Math.round(p.y) >= ROWS || below){
-          if(below){ below.falling=true; }
-          p.falling=false;
-          p.y = below ? below.y-1 : ROWS;
-          if(p.y>=ROWS){
-            // piece completed
-            p.complete=true;
+          if(below){ below.falling = true; }
+          p.falling = false;
+          p.y = below ? below.y - 1 : ROWS;
+          if(p.y >= ROWS){
+            p.complete = true;
           }
         }
       }
     }
+    ridePieces(player);
 
     // enemy movement
     for(const e of enemies){
-      if(e.stunned>0){ e.stunned--; continue; }
-      if(e.x < player.x) e.vx=0.05; else if(e.x>player.x) e.vx=-0.05; else e.vx=0;
+      if(e.stunned>0){ e.stunned--; ridePieces(e); continue; }
+      if(isSupported(e)){
+        if(e.x < player.x) e.vx=0.05; else if(e.x>player.x) e.vx=-0.05; else e.vx=0;
+      } else {
+        e.vx = 0;
+      }
       e.x += e.vx;
       e.x = Math.max(0, Math.min(COLS-1, e.x));
       // simple vertical chase
@@ -167,6 +198,7 @@
         gameOver=true;
         document.getElementById('message').textContent='Game Over';
       }
+      ridePieces(e);
     }
 
     if(pieces.every(p=>p.complete)){
@@ -199,16 +231,23 @@
     ctx.save();
     ctx.scale(TILE, TILE);
     // floors
-    ctx.fillStyle='#555';
-    for(const f of floors){
-      ctx.fillRect(0,f-0.1,COLS,0.1);
+    ctx.fillStyle = '#8b5a2b';
+    for (const f of floors) {
+      ctx.fillRect(0, f - 0.1, COLS, 0.2);
     }
     // ladders
-    ctx.strokeStyle='#aaa';
-    for(const l of ladders){
+    ctx.strokeStyle = '#d8c18f';
+    ctx.lineWidth = 0.05;
+    for (const l of ladders) {
       ctx.beginPath();
-      ctx.moveTo(l.x+0.5,l.top);
-      ctx.lineTo(l.x+0.5,l.bottom);
+      ctx.moveTo(l.x + 0.2, l.top);
+      ctx.lineTo(l.x + 0.2, l.bottom);
+      ctx.moveTo(l.x + 0.8, l.top);
+      ctx.lineTo(l.x + 0.8, l.bottom);
+      for (let y = l.top + 0.5; y < l.bottom; y += 0.5) {
+        ctx.moveTo(l.x + 0.2, y);
+        ctx.lineTo(l.x + 0.8, y);
+      }
       ctx.stroke();
     }
     // pieces


### PR DESCRIPTION
## Summary
- update guidance to Burger Time as the active game
- improve Burger Builder background and canvas styling
- draw ladders with rails and rungs and make floors thicker
- restrict player/enemy movement to floors, ladders or burger pieces
- allow player and enemies to ride falling burger pieces

## Testing
- `node test_egg.js` *(fails: Egg is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687e20296e4483318ffb3ae820855af2