### PR TITLE
Improve tanks clone with levels and bouncing bullets

### DIFF
--- a/tanks.html
+++ b/tanks.html
@@ -47,6 +47,7 @@
   <div id="sidebar-placeholder"></div>
   <div id="game-container">
     <h1>Tanks</h1>
+    <label style="margin-bottom:10px;"><input type="checkbox" id="bounceToggle"> Bouncing bullets</label>
     <canvas id="gameCanvas" width="800" height="600"></canvas>
     <div id="info"></div>
     <div id="message"></div>
@@ -57,91 +58,147 @@
 
     const keys = {};
     const bullets = [];
+    const obstacles = [];
 
-    const player = {x:100,y:canvas.height/2,angle:0,lives:3,color:'#0f0'};
-    const enemy = {x:canvas.width-100,y:canvas.height/2,angle:Math.PI,lives:3,color:'#f00',shootTimer:0};
-
+    const player = {x:0,y:0,angle:0,color:'#0f0',alive:true,explosion:0};
+    let enemies = [];
+    let level = 1;
     let running = false;
 
-    function shoot(tank){
-      bullets.push({x:tank.x + Math.cos(tank.angle)*20,
-                    y:tank.y + Math.sin(tank.angle)*20,
-                    angle:tank.angle,
-                    owner:tank});
+    function obstacleCollision(x, y) {
+      for (const o of obstacles) {
+        if (x > o.x - 15 && x < o.x + o.w + 15 && y > o.y - 15 && y < o.y + o.h + 15) return true;
+      }
+      return false;
     }
 
-    function updateInfo(){
-      document.getElementById('info').textContent = `Player Lives: ${player.lives} | Enemy Lives: ${enemy.lives}`;
+    function respawnPlayer() {
+      for (let i = 0; i < 100; i++) {
+        const x = 30 + Math.random() * (canvas.width - 60);
+        const y = 30 + Math.random() * (canvas.height - 60);
+        if (!obstacleCollision(x, y) && enemies.every(e => !e.alive || Math.hypot(x - e.x, y - e.y) > 120)) {
+          player.x = x; player.y = y; player.angle = 0; player.alive = true; player.explosion = 0;
+          return;
+        }
+      }
+      player.x = 100; player.y = canvas.height / 2; player.angle = 0; player.alive = true; player.explosion = 0;
     }
 
-    function resetGame(){
-      player.x = 100; player.y = canvas.height/2; player.angle = 0; player.lives = 3;
-      enemy.x = canvas.width-100; enemy.y = canvas.height/2; enemy.angle = Math.PI; enemy.lives = 3; enemy.shootTimer = 0;
+    function createObstacles() {
+      obstacles.length = 0;
+      for (let i = 0; i < 5; i++) {
+        const w = 40 + Math.random() * 60;
+        const h = 40 + Math.random() * 60;
+        const x = 20 + Math.random() * (canvas.width - w - 40);
+        const y = 20 + Math.random() * (canvas.height - h - 40);
+        obstacles.push({ x, y, w, h });
+      }
+    }
+
+    function startLevel() {
       bullets.length = 0;
-      running = true;
+      createObstacles();
+      enemies = [];
+      for (let i = 0; i < level + 1; i++) {
+        let x = 30 + Math.random() * (canvas.width - 60);
+        let y = 30 + Math.random() * (canvas.height - 60);
+        let tries = 0;
+        while ((obstacleCollision(x, y) || (Math.hypot(x - player.x, y - player.y) < 120)) && tries < 50) {
+          x = 30 + Math.random() * (canvas.width - 60);
+          y = 30 + Math.random() * (canvas.height - 60);
+          tries++;
+        }
+        enemies.push({ x, y, angle: Math.PI, shootTimer: 80, color: '#f00', alive: true, explosion: 0 });
+      }
+      respawnPlayer();
       document.getElementById('message').textContent = '';
+      running = true;
       updateInfo();
     }
 
-    function update(){
-      if(!running) return;
-      if(keys['ArrowUp']){ player.x += Math.cos(player.angle)*2; player.y += Math.sin(player.angle)*2; }
-      if(keys['ArrowDown']){ player.x -= Math.cos(player.angle)*2; player.y -= Math.sin(player.angle)*2; }
-      if(keys['ArrowLeft']) player.angle -= 0.05;
-      if(keys['ArrowRight']) player.angle += 0.05;
+    function shoot(tank) {
+      if (bullets.filter(b => b.owner === tank).length >= 2) return;
+      bullets.push({ x: tank.x + Math.cos(tank.angle) * 20,
+                    y: tank.y + Math.sin(tank.angle) * 20,
+                    angle: tank.angle,
+                    owner: tank });
+    }
 
-      player.x = Math.max(15, Math.min(canvas.width-15, player.x));
-      player.y = Math.max(15, Math.min(canvas.height-15, player.y));
+    function updateInfo() {
+      const remaining = enemies.filter(e => e.alive).length;
+      document.getElementById('info').textContent = `Level: ${level} | Enemies Left: ${remaining}`;
+    }
 
-      // enemy AI
-      const dx = player.x - enemy.x;
-      const dy = player.y - enemy.y;
-      const desired = Math.atan2(dy, dx);
-      let diff = ((desired - enemy.angle + Math.PI*3) % (Math.PI*2)) - Math.PI;
-      if(Math.abs(diff) > 0.02) enemy.angle += Math.sign(diff)*0.02;
-      enemy.x += Math.cos(enemy.angle)*1.5;
-      enemy.y += Math.sin(enemy.angle)*1.5;
-      enemy.x = Math.max(15, Math.min(canvas.width-15, enemy.x));
-      enemy.y = Math.max(15, Math.min(canvas.height-15, enemy.y));
+    function update() {
+      if (!running) return;
+      const bounce = document.getElementById('bounceToggle').checked;
 
-      enemy.shootTimer--;
-      if(enemy.shootTimer <= 0){
-        shoot(enemy);
-        enemy.shootTimer = 80;
+      if (player.alive) {
+        let nx = player.x, ny = player.y, na = player.angle;
+        if (keys['ArrowLeft']) na -= 0.05;
+        if (keys['ArrowRight']) na += 0.05;
+        if (keys['ArrowUp']) { nx += Math.cos(na) * 2; ny += Math.sin(na) * 2; }
+        if (keys['ArrowDown']) { nx -= Math.cos(na) * 2; ny -= Math.sin(na) * 2; }
+        nx = Math.max(15, Math.min(canvas.width - 15, nx));
+        ny = Math.max(15, Math.min(canvas.height - 15, ny));
+        if (!obstacleCollision(nx, ny)) { player.x = nx; player.y = ny; }
+        player.angle = na;
+      } else if (player.explosion > 0) {
+        player.explosion--;
+        if (player.explosion === 0) respawnPlayer();
       }
 
-      for(let i=bullets.length-1;i>=0;i--){
+      for (const e of enemies) {
+        if (!e.alive) { if (e.explosion > 0) e.explosion--; continue; }
+        const dx = player.x - e.x;
+        const dy = player.y - e.y;
+        const desired = Math.atan2(dy, dx);
+        let diff = ((desired - e.angle + Math.PI * 3) % (Math.PI * 2)) - Math.PI;
+        if (Math.abs(diff) > 0.02) e.angle += Math.sign(diff) * 0.02;
+        let ex = e.x + Math.cos(e.angle) * 1.5;
+        let ey = e.y + Math.sin(e.angle) * 1.5;
+        ex = Math.max(15, Math.min(canvas.width - 15, ex));
+        ey = Math.max(15, Math.min(canvas.height - 15, ey));
+        if (!obstacleCollision(ex, ey)) { e.x = ex; e.y = ey; }
+        e.shootTimer--;
+        if (e.shootTimer <= 0 && player.alive) { shoot(e); e.shootTimer = 80; }
+      }
+
+      for (let i = bullets.length - 1; i >= 0; i--) {
         const b = bullets[i];
-        b.x += Math.cos(b.angle)*4;
-        b.y += Math.sin(b.angle)*4;
-        if(b.x < 0 || b.x > canvas.width || b.y < 0 || b.y > canvas.height){
-          bullets.splice(i,1);
+        b.x += Math.cos(b.angle) * 4;
+        b.y += Math.sin(b.angle) * 4;
+        if (b.x < 0 || b.x > canvas.width || b.y < 0 || b.y > canvas.height) { bullets.splice(i, 1); continue; }
+        let removed = false;
+        for (const o of obstacles) {
+          if (b.x > o.x && b.x < o.x + o.w && b.y > o.y && b.y < o.y + o.h) { bullets.splice(i, 1); removed = true; break; }
+        }
+        if (removed) continue;
+        if (player.alive && b.owner !== player && Math.hypot(b.x - player.x, b.y - player.y) < 15) {
+          player.alive = false; player.explosion = 30;
+          if (!bounce) { bullets.splice(i, 1); } else { b.angle = Math.atan2(b.y - player.y, b.x - player.x); }
           continue;
         }
-        if(b.owner !== player && Math.hypot(b.x - player.x, b.y - player.y) < 15){
-          bullets.splice(i,1);
-          player.lives--;
-          updateInfo();
-          if(player.lives <= 0){
-            running = false;
-            document.getElementById('message').textContent = 'Game Over - Press Enter';
+        for (const e of enemies) {
+          if (e.alive && b.owner !== e && Math.hypot(b.x - e.x, b.y - e.y) < 15) {
+            e.alive = false; e.explosion = 30;
+            if (!bounce) { bullets.splice(i, 1); } else { b.angle = Math.atan2(b.y - e.y, b.x - e.x); }
+            removed = true; break;
           }
-          continue;
         }
-        if(b.owner !== enemy && Math.hypot(b.x - enemy.x, b.y - enemy.y) < 15){
-          bullets.splice(i,1);
-          enemy.lives--;
-          updateInfo();
-          if(enemy.lives <= 0){
-            running = false;
-            document.getElementById('message').textContent = 'You Win! - Press Enter';
-          }
-          continue;
-        }
+        if (removed && !bounce) continue;
+      }
+
+      updateInfo();
+
+      if (enemies.every(e => !e.alive && e.explosion === 0)) {
+        running = false;
+        document.getElementById('message').textContent = 'Next Level';
+        setTimeout(() => { level++; startLevel(); }, 1000);
       }
     }
 
-    function drawTank(t){
+    function drawTank(t) {
       ctx.save();
       ctx.translate(t.x, t.y);
       ctx.rotate(t.angle);
@@ -151,19 +208,31 @@
       ctx.restore();
     }
 
-    function draw(){
-      ctx.clearRect(0,0,canvas.width,canvas.height);
-      drawTank(player);
-      drawTank(enemy);
+    function drawExplosion(t) {
+      const r = 30 - t.explosion;
+      ctx.fillStyle = 'orange';
+      ctx.beginPath();
+      ctx.arc(t.x, t.y, r, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    function draw() {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = '#666';
+      for (const o of obstacles) ctx.fillRect(o.x, o.y, o.w, o.h);
+      if (player.alive) drawTank(player); else if (player.explosion > 0) drawExplosion(player);
+      for (const e of enemies) {
+        if (e.alive) drawTank(e); else if (e.explosion > 0) drawExplosion(e);
+      }
       ctx.fillStyle = '#fff';
-      for(const b of bullets){
+      for (const b of bullets) {
         ctx.beginPath();
-        ctx.arc(b.x, b.y, 3, 0, Math.PI*2);
+        ctx.arc(b.x, b.y, 3, 0, Math.PI * 2);
         ctx.fill();
       }
     }
 
-    function loop(){
+    function loop() {
       update();
       draw();
       requestAnimationFrame(loop);
@@ -171,12 +240,11 @@
 
     window.addEventListener('keydown', e => {
       keys[e.key] = true;
-      if(e.key === ' ' && running){ shoot(player); }
-      if(e.key === 'Enter' && !running){ resetGame(); }
+      if (e.key === ' ' && running && player.alive) { shoot(player); }
     });
     window.addEventListener('keyup', e => { keys[e.key] = false; });
 
-    window.addEventListener('load', () => { resetGame(); loop(); });
+    window.addEventListener('load', () => { startLevel(); loop(); });
   </script>
   <script>
     fetch('sidebar.html')


### PR DESCRIPTION
## Summary
- add UI checkbox to toggle bouncing bullets
- add obstacles, multiple enemies and level progression
- respawn player away from enemies
- show explosion animation and next-level message
- restrict tanks to two bullets

## Testing
- `node -c /tmp/script.js`

------
https://chatgpt.com/codex/tasks/task_e_687ec6813d088331a2cd604f8ddf97aa