### PR TITLE
Add next block preview to Tetris

### DIFF
--- a/tetris.html
+++ b/tetris.html
@@ -53,6 +53,15 @@
       padding: 5px 10px;
       border-radius: 5px;
     }
+    #next {
+      margin-top: 10px;
+      text-align: center;
+    }
+    #nextCanvas {
+      background: #000;
+      box-shadow: 0 0 5px #000;
+      margin-top: 5px;
+    }
     #message {
       margin-top: 10px;
       font-size: 24px;
@@ -66,11 +75,14 @@
     <h1>Tetris</h1>
     <canvas id="gameCanvas" width="300" height="600"></canvas>
     <div id="info">Score: 0 | Lines: 0</div>
+    <div id="next">Next:<br><canvas id="nextCanvas" width="120" height="120"></canvas></div>
     <div id="message"></div>
   </div>
   <script>
     const canvas = document.getElementById('gameCanvas');
     const ctx = canvas.getContext('2d');
+    const nextCanvas = document.getElementById('nextCanvas');
+    const nextCtx = nextCanvas.getContext('2d');
     const COLS = 10;
     const ROWS = 20;
     const BLOCK = 30;
@@ -121,6 +133,7 @@
     ];
     let board;
     let current;
+    let nextType;
     let score = 0;
     let lines = 0;
     let dropInterval = 1000;
@@ -134,8 +147,13 @@
     }
 
     function newPiece() {
-      const type = Math.floor(Math.random()*SHAPES.length);
+      if (nextType === undefined) {
+        nextType = Math.floor(Math.random()*SHAPES.length);
+      }
+      const type = nextType;
       current = {type, rot:0, x:3, y:0};
+      nextType = Math.floor(Math.random()*SHAPES.length);
+      drawNextPiece();
       if (collide(0,0,0)) {
         gameOver = true;
       }
@@ -220,6 +238,15 @@
       ctx.fillRect(x*BLOCK, y*BLOCK, BLOCK-1, BLOCK-1);
     }
 
+    function drawNextPiece() {
+      nextCtx.fillStyle = '#111';
+      nextCtx.fillRect(0,0,nextCanvas.width,nextCanvas.height);
+      SHAPES[nextType][0].forEach(([x,y]) => {
+        nextCtx.fillStyle = COLORS[nextType];
+        nextCtx.fillRect(x*BLOCK, y*BLOCK, BLOCK-1, BLOCK-1);
+      });
+    }
+
     function draw() {
       ctx.fillStyle = '#111';
       ctx.fillRect(0,0,canvas.width,canvas.height);
@@ -271,6 +298,7 @@
       lines = 0;
       gameOver = false;
       resetBoard();
+      nextType = Math.floor(Math.random()*SHAPES.length);
       newPiece();
       lastTime = 0;
       update();


### PR DESCRIPTION
## Summary
- show the next Tetris piece in a separate canvas
- initialize and update preview when spawning pieces

## Testing
- `node -c test_egg.js`

------
https://chatgpt.com/codex/tasks/task_e_687ec6d596888331aedbeb4ee16460a3