### PR TITLE
Update mine placement in Tanks

### DIFF
--- a/tanks.html
+++ b/tanks.html
@@ -328,7 +328,13 @@
       keys[e.key] = true;
       if (e.key === ' ' && running && player.alive) { shoot(player); }
       if ((e.key === 'm' || e.key === 'M') && running && player.alive && !mine) {
-        mine = { x: player.x, y: player.y, timer: 180, explosion: 0 };
+        const offset = 16; // place mine just behind the tank with 1px gap
+        mine = {
+          x: player.x - Math.cos(player.angle) * offset,
+          y: player.y - Math.sin(player.angle) * offset,
+          timer: 180,
+          explosion: 0
+        };
       }
     });
     window.addEventListener('keyup', e => { keys[e.key] = false; });


### PR DESCRIPTION
## Summary
- place the player's mine behind the tank instead of at the current position

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687f7a5e448c8331bd15ebe8e5159f4b