### PR TITLE
Fix burger game ladder movement

### DIFF
--- a/burger.html
+++ b/burger.html
@@ -195,7 +195,7 @@
     if(keys.up && ladderAt(player.x, player.y)) player.y -=0.1;
     if(keys.down && ladderAt(player.x, player.y)) player.y +=0.1;
     player.x = Math.max(0, Math.min(COLS-1, player.x));
-    player.y = Math.max(1, Math.min(ROWS-1, player.y));
+    player.y = Math.max(1, Math.min(ROWS, player.y));
 
     const px=Math.round(player.x), py=Math.round(player.y);
     const piece = pieceUnder(player);


### PR DESCRIPTION
## Summary
- allow player to reach bottom floor in Burger Builder by adjusting bounds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882d56d6330833199b7e0e3e9b9c260