### PR TITLE
Update Pac‑Man level handling

### DIFF
--- a/pacman.html
+++ b/pacman.html
@@ -64,7 +64,7 @@
   <div id="sidebar-placeholder"></div>
   <div id="game-container">
     <h1>Pac-Man</h1>
-    <canvas id="gameCanvas" width="560" height="620"></canvas>
+    <canvas id="gameCanvas" width="800" height="680"></canvas>
     <div id="info">Score: 0 | Lives: 3 | Level: 1</div>
     <div id="message"></div>
   </div>
@@ -74,9 +74,9 @@ const ctx = canvas.getContext('2d');
 
 const TILE = 20; // each tile is 20x20
 
-// simple map layout (20x20) using characters:
+// base map layout using characters:
 // # wall, . pellet, o power pellet, ' ' empty
-const map = [
+const baseMap = [
   '####################',
   '#........##........#',
   '#.##.###.##.###.##.#',
@@ -95,8 +95,16 @@ const map = [
   '#o.. ....P..... ..o#',
   '####################'
 ];
-const ROWS = map.length;
-const COLS = map[0].length;
+
+function makeSymmetricalMap(map) {
+  const horiz = map.map(row => row + row.split('').reverse().join(''));
+  return horiz.concat(horiz.slice().reverse());
+}
+
+let initialMap = makeSymmetricalMap(baseMap);
+let map = initialMap.map(r => r);
+let ROWS = map.length;
+let COLS = map[0].length;
 canvas.width = COLS*TILE;
 canvas.height = ROWS*TILE;
 
@@ -114,24 +122,42 @@ let level=1;
 let frightTimer=0;
 let message='';
 
-for(let r=0;r<ROWS;r++){
-  for(let c=0;c<COLS;c++){
-    const ch=map[r][c];
-    if(ch==='.'|| ch==='o') pellets++;
+function countPellets(){
+  pellets=0;
+  for(let r=0;r<ROWS;r++){
+    for(let c=0;c<COLS;c++){
+      const ch=map[r][c];
+      if(ch==='.'|| ch==='o') pellets++;
+    }
   }
 }
 
-function resetLevel(){
+countPellets();
+
+let startTimer=0;
+
+function resetPositions(){
   pacman.x=9; pacman.y=15; pacman.dir={x:0,y:0}; pacman.nextDir={x:0,y:0}; pacman.speed=0.125;
   ghosts[0].x=9; ghosts[0].y=10; ghosts[0].speed=0.125;
   ghosts[1].x=10; ghosts[1].y=10; ghosts[1].speed=0.125;
   ghosts[2].x=8; ghosts[2].y=10; ghosts[2].speed=0.125;
   ghosts[3].x=11; ghosts[3].y=10; ghosts[3].speed=0.125;
+  startTimer=120; // 2 seconds at ~60fps
   frightTimer=0; message='';
 }
 
+function startLevel(){
+  map = initialMap.map(r => r);
+  ROWS = map.length;
+  COLS = map[0].length;
+  canvas.width = COLS*TILE;
+  canvas.height = ROWS*TILE;
+  countPellets();
+  resetPositions();
+}
+
 function resetGame(){
-  score=0; lives=3; level=1; resetLevel();
+  score=0; lives=3; level=1; startLevel();
 }
 
 function tileAt(x,y){
@@ -192,6 +218,7 @@ function updatePacman(){
 }
 
 function ghostTarget(g){
+  if(startTimer>0) return {x:COLS/2, y:ROWS/2};
   if(frightTimer>0) return {x:g.scatter.x,y:g.scatter.y};
   return {x:pacman.x,y:pacman.y};
 }
@@ -222,13 +249,12 @@ function checkCollisions(){
       if(frightTimer>0){
         score+=200; g.x=9; g.y=10; g.dir={x:0,y:0};
       }else{
-        lives--; message='Ouch!'; resetLevel();
+        lives--; message='Ouch!'; resetPositions();
       }
     }
   }
   if(pellets===0){
-    level++; message='Next Level!'; setTimeout(()=>{resetLevel();},1000);
-    pellets=0; for(let r=0;r<ROWS;r++) for(let c=0;c<COLS;c++){const ch=map[r][c]; if(ch==='.'||ch==='o') pellets++;}
+    level++; message='Next Level!'; setTimeout(()=>{startLevel();},1000);
   }
   if(lives===0){ message='Game Over'; pacman.dir={x:0,y:0}; }
 }
@@ -255,6 +281,7 @@ function gameLoop(){
   ghosts.forEach(updateGhost);
   checkCollisions();
   if(frightTimer>0) frightTimer--;
+  if(startTimer>0) startTimer--;
   draw();
   requestAnimationFrame(gameLoop);
 }


### PR DESCRIPTION
## Summary
- build a bigger symmetrical board for Pac-Man
- add `startLevel` and `resetPositions` helpers
- make ghosts move toward the center for 2s at level start
- reset pellets and positions when a level is cleared

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6882d53e3a188331b8acbbeb7b8636f4