### PR TITLE
Fix game speed by using fixed loop interval

### DIFF
--- a/burger.html
+++ b/burger.html
@@ -370,12 +370,12 @@
     if(e.key==='ArrowDown') keys.down=false;
   });
 
+  const FRAME_TIME = 1000/60;
   function loop(){
     update();
     draw();
-    requestAnimationFrame(loop);
   }
-  loop();
+  setInterval(loop, FRAME_TIME);
   </script>
   <script>
     fetch('sidebar.html')

--- a/drop-game.html
+++ b/drop-game.html
@@ -266,6 +266,7 @@
       bullets.forEach(drawBullet);
     }
 
+    const FRAME_TIME = 1000/60;
     function step() {
       if (gameOver) return;
       if (rightPressed && basketX < canvas.width - basketWidth) basketX += 5;
@@ -284,10 +285,9 @@
         }, 3000);
       }
       draw();
-      requestAnimationFrame(step);
     }
     draw();
-    step();
+    setInterval(step, FRAME_TIME);
   </script>
   <script>
     fetch('sidebar.html')

--- a/flappy.html
+++ b/flappy.html
@@ -229,16 +229,16 @@
     }
   }
 
+  const FRAME_TIME = 1000/60;
   function loop() {
     update();
     draw();
-    requestAnimationFrame(loop);
   }
 
   window.addEventListener('load', () => {
     resizeGame();
     resetGame();
-    loop();
+    setInterval(loop, FRAME_TIME);
   });
   window.addEventListener('resize', resizeGame);
   </script>

--- a/joust.html
+++ b/joust.html
@@ -533,7 +533,7 @@
     resizeGame();
     startStage();
     resetPlayer();
-    loop();
+    setInterval(loop, FRAME_TIME);
   }
 
   function update(){
@@ -605,10 +605,10 @@
     }
   }
 
+  const FRAME_TIME = 1000/60;
   function loop(){
     update();
     draw();
-    requestAnimationFrame(loop);
   }
   window.addEventListener('load', initGame);
   </script>

--- a/missile-command.html
+++ b/missile-command.html
@@ -207,15 +207,12 @@
       });
     }
 
-    let last = performance.now();
+    const FRAME_TIME = 1000/60;
     function loop() {
-      const now = performance.now();
-      const dt = (now - last) / 1000;
-      last = now;
-      update(dt);
+      update(1/60);
       draw();
-      requestAnimationFrame(loop);
     }
+    setInterval(loop, FRAME_TIME);
 
     function updateInfo() {
       document.getElementById('info').textContent = `Score: ${score} | Lives: ${lives}`;

--- a/pacman.html
+++ b/pacman.html
@@ -250,13 +250,13 @@ function draw(){
   document.getElementById('message').textContent=message;
 }
 
+const FRAME_TIME = 1000/60;
 function gameLoop(){
   updatePacman();
   ghosts.forEach(updateGhost);
   checkCollisions();
   if(frightTimer>0) frightTimer--;
   draw();
-  requestAnimationFrame(gameLoop);
 }
 
 document.addEventListener('keydown',e=>{
@@ -268,7 +268,7 @@ document.addEventListener('keydown',e=>{
 });
 
 resetGame();
-requestAnimationFrame(gameLoop);
+setInterval(gameLoop, FRAME_TIME);
 </script>
 <script>
   fetch('sidebar.html')

--- a/pinball.html
+++ b/pinball.html
@@ -522,15 +522,12 @@
       drawBall();
     }
 
-    let lastTime = performance.now();
+    const FRAME_TIME = 1000/60;
     function step(){
-      const now = performance.now();
-      const dt = (now - lastTime)/1000;
-      lastTime = now;
+      const dt = 1/60;
       updateFlippers(dt);
       updatePhysics();
       draw();
-      requestAnimationFrame(step);
     }
 
     document.addEventListener('keydown', e=>{
@@ -553,7 +550,7 @@
     resetBall();
     initSVG();
     updateInfo();
-    step();
+    setInterval(step, FRAME_TIME);
   </script>
   <script>
     fetch('sidebar.html')

--- a/tanks.html
+++ b/tanks.html
@@ -318,11 +318,12 @@
       }
     }
 
+    const FRAME_TIME = 1000/60;
     function loop() {
       update();
       draw();
-      requestAnimationFrame(loop);
     }
+    setInterval(loop, FRAME_TIME);
 
     window.addEventListener('keydown', e => {
       keys[e.key] = true;


### PR DESCRIPTION
## Summary
- stabilize game speed by running loops at a fixed 60FPS
- apply fix to Missile Command, Tanks, Burger Time, Pac-Man, Joust, Drop Game, Flappy, and Pinball

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6882d40a808c8331b3fb4d8b0ffcd191