### PR TITLE
Fix air raid explosion offset

### DIFF
--- a/ultra-tanks.html
+++ b/ultra-tanks.html
@@ -352,11 +352,13 @@
         };
       }
     });
-    canvas.addEventListener('click', e => {
-      if (!running || airRaidAvailable <= 0) return;
-      const rect = canvas.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const y = e.clientY - rect.top;
+      canvas.addEventListener('click', e => {
+        if (!running || airRaidAvailable <= 0) return;
+        const rect = canvas.getBoundingClientRect();
+        const scaleX = canvas.width / rect.width;
+        const scaleY = canvas.height / rect.height;
+        const x = (e.clientX - rect.left) * scaleX;
+        const y = (e.clientY - rect.top) * scaleY;
       const r = Math.sqrt(0.2 * canvas.width * canvas.height / Math.PI);
       airRaidExplosion = { x, y, r, timer: 30 };
       airRaidAvailable--;


### PR DESCRIPTION
## Summary
- ensure the air raid centers on the actual click position in **Ultra Tanks**

## Testing
- `node -e "console.log('Node OK')"`
- `node test_egg.js` *(fails: Egg is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6882de1968dc8331a45b5e8a3093640e