### PR TITLE
Slow down ultra tanks

### DIFF
--- a/ultra-tanks.html
+++ b/ultra-tanks.html
@@ -333,11 +333,12 @@
       }
     }
 
+    const FRAME_TIME = 1000/60;
     function loop() {
       update();
       draw();
-      requestAnimationFrame(loop);
     }
+    setInterval(loop, FRAME_TIME);
 
     window.addEventListener('keydown', e => {
       keys[e.key] = true;


### PR DESCRIPTION
## Summary
- fix Ultra Tanks game loop to use a fixed 60 FPS interval

## Testing
- `node -e "console.log('no tests')"`

------
https://chatgpt.com/codex/tasks/task_e_6882dee85c848331a913990a08eaa733