### PR TITLE
Enhance qbert clone

### DIFF
--- a/images/qbert.svg
+++ b/images/qbert.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="16" cy="16" r="14" fill="#ff9800" stroke="#e65100" stroke-width="2"/>
+  <polygon points="16,10 24,14 16,18" fill="#ffcc80"/>
+  <circle cx="12" cy="14" r="2" fill="#000"/>
+  <circle cx="18" cy="14" r="2" fill="#000"/>
+</svg>

--- a/images/qbert_enemy.svg
+++ b/images/qbert_enemy.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="16" cy="16" r="14" fill="#9c27b0" stroke="#6a1b9a" stroke-width="2"/>
+  <circle cx="12" cy="14" r="2" fill="#fff"/>
+  <circle cx="20" cy="14" r="2" fill="#fff"/>
+</svg>

--- a/images/qbert_platform.svg
+++ b/images/qbert_platform.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <ellipse cx="16" cy="16" rx="14" ry="6" fill="#b3e5fc" stroke="#0288d1" stroke-width="2"/>
+</svg>

--- a/qbert.html
+++ b/qbert.html
@@ -43,28 +43,35 @@
   <div id="sidebar-placeholder"></div>
   <div id="game-container">
     <h1>Qbert Clone</h1>
-    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <canvas id="gameCanvas" width="600" height="600"></canvas>
     <div id="info"></div>
     <div id="message"></div>
   </div>
   <script>
     const canvas = document.getElementById('gameCanvas');
     const ctx = canvas.getContext('2d');
-    const ROWS = 5;
-    const TILE = 40;
+    const ROWS = 7;
+    const TILE = 50;
     const START_X = canvas.width/2;
     const START_Y = 60;
+    const COLORS = ['#2196f3','#ff9800','#4caf50','#e91e63','#9c27b0','#00bcd4','#ffc107'];
 
-    const tiles = [];
-    for(let r=0;r<ROWS;r++){
-      tiles[r]=[];
-      for(let c=0;c<=r;c++) tiles[r][c]=false;
-    }
-    let visited = 0;
-    tiles[0][0]=true;
-    visited++;
+    const qbertImg = new Image();
+    qbertImg.src = 'images/qbert.svg';
+    const enemyImg = new Image();
+    enemyImg.src = 'images/qbert_enemy.svg';
+    const platformImg = new Image();
+    platformImg.src = 'images/qbert_platform.svg';
 
+    let level = 1;
+    let lives = 3;
+    let tiles;
+    let visited;
     const qbert = {row:0,col:0};
+    const enemy = {row:ROWS-1,col:ROWS-1};
+    const leftPlatform = {used:false};
+    const rightPlatform = {used:false};
+
     const infoEl = document.getElementById('info');
     const messageEl = document.getElementById('message');
 
@@ -72,6 +79,18 @@
       const x = START_X - (r*TILE)/2 + c*TILE;
       const y = START_Y + r*(TILE*0.75);
       return {x,y};
+    }
+
+    function platformPos(side){
+      const base = tilePos(ROWS-2, side==='left'?0:ROWS-2);
+      return {x: base.x + (side==='left'? -TILE : TILE), y: base.y};
+    }
+
+    function visitTile(r,c){
+      if(tiles[r][c] < level){
+        tiles[r][c]++;
+        if(tiles[r][c] === level) visited++;
+      }
     }
 
     function drawTile(r,c){
@@ -82,10 +101,22 @@
       ctx.lineTo(x+TILE/2,y+TILE);
       ctx.lineTo(x,y+TILE/2);
       ctx.closePath();
-      ctx.fillStyle = tiles[r][c] ? '#ff9800' : '#2196f3';
+      const idx = Math.min(tiles[r][c], level);
+      ctx.fillStyle = COLORS[idx];
       ctx.fill();
       ctx.strokeStyle = '#555';
       ctx.stroke();
+    }
+
+    function drawPlatforms(){
+      if(!leftPlatform.used){
+        const p = platformPos('left');
+        ctx.drawImage(platformImg,p.x,p.y,TILE,TILE*0.6);
+      }
+      if(!rightPlatform.used){
+        const p = platformPos('right');
+        ctx.drawImage(platformImg,p.x,p.y,TILE,TILE*0.6);
+      }
     }
 
     function draw(){
@@ -95,40 +126,124 @@
           drawTile(r,c);
         }
       }
-      const {x,y} = tilePos(qbert.row,qbert.col);
-      ctx.beginPath();
-      ctx.arc(x+TILE/2,y+TILE/2,12,0,Math.PI*2);
-      ctx.fillStyle = '#ffeb3b';
-      ctx.fill();
-      infoEl.textContent = `Tiles changed: ${visited}/${ROWS*(ROWS+1)/2}`;
+      drawPlatforms();
+      const q = tilePos(qbert.row,qbert.col);
+      ctx.drawImage(qbertImg,q.x+TILE/2-16,q.y+TILE/2-16,32,32);
+      const e = tilePos(enemy.row,enemy.col);
+      ctx.drawImage(enemyImg,e.x+TILE/2-16,e.y+TILE/2-16,32,32);
+      infoEl.textContent = `Level: ${level} Lives: ${lives} - ${visited}/${ROWS*(ROWS+1)/2}`;
     }
 
     function checkWin(){
       if(visited === ROWS*(ROWS+1)/2){
-        messageEl.textContent = 'You win!';
+        messageEl.textContent = `Level ${level} complete!`;
+        level++;
+        setTimeout(startLevel, 1000);
       }
+    }
+
+    function loseLife(){
+      lives--;
+      if(lives <= 0){
+        messageEl.textContent = 'Game Over';
+      } else {
+        qbert.row=0; qbert.col=0;
+        enemy.row=ROWS-1; enemy.col=ROWS-1;
+      }
+      draw();
+    }
+
+    function enemyMove(){
+      let bestR = enemy.row;
+      let bestC = enemy.col;
+      let bestDist = Infinity;
+      const target = tilePos(qbert.row,qbert.col);
+      const options = [
+        [enemy.row+1, enemy.col],
+        [enemy.row+1, enemy.col+1],
+        [enemy.row-1, enemy.col],
+        [enemy.row-1, enemy.col-1]
+      ];
+      for(const [nr,nc] of options){
+        if(nr<0 || nr>=ROWS || nc<0 || nc>nr) continue;
+        const pos = tilePos(nr,nc);
+        const d = (pos.x-target.x)**2 + (pos.y-target.y)**2;
+        if(d < bestDist){ bestDist=d; bestR=nr; bestC=nc; }
+      }
+      enemy.row = bestR;
+      enemy.col = bestC;
+    }
+
+    function usePlatform(p){
+      p.used = true;
+      qbert.row = 0; qbert.col = 0;
     }
 
     function move(dr,dc){
-      const nr = qbert.row+dr;
-      const nc = qbert.col+dc;
-      if(nr<0 || nr>=ROWS || nc<0 || nc>nr) return;
-      qbert.row=nr; qbert.col=nc;
-      if(!tiles[nr][nc]){ tiles[nr][nc]=true; visited++; }
+      if(lives <= 0) return;
+      let nr = qbert.row + dr;
+      let nc = qbert.col + dc;
+      if(qbert.row === ROWS-2 && dr === 1){
+        if(dc === 0 && qbert.col === 0 && !leftPlatform.used){
+          usePlatform(leftPlatform);
+          draw();
+          return;
+        }
+        if(dc === 1 && qbert.col === ROWS-2 && !rightPlatform.used){
+          usePlatform(rightPlatform);
+          draw();
+          return;
+        }
+      }
+      if(nr<0 || nr>=ROWS || nc<0 || nc>nr){
+        loseLife();
+        return;
+      }
+      qbert.row = nr; qbert.col = nc;
+      visitTile(nr,nc);
+      enemyMove();
       draw();
+      if(enemy.row === qbert.row && enemy.col === qbert.col){
+        loseLife();
+      }
       checkWin();
     }
 
-    document.addEventListener('keydown',e=>{
+    function startLevel(){
+      tiles = [];
+      for(let r=0;r<ROWS;r++){
+        tiles[r]=[];
+        for(let c=0;c<=r;c++) tiles[r][c]=0;
+      }
+      visited = 0;
+      leftPlatform.used = false;
+      rightPlatform.used = false;
+      qbert.row = 0; qbert.col = 0;
+      enemy.row = ROWS-1; enemy.col = ROWS-1;
+      visitTile(0,0);
+      messageEl.textContent = '';
+      draw();
+    }
+
+    document.addEventListener('keydown', e => {
       switch(e.key){
-        case 'ArrowUp': move(-1,-1); break; // up-left
-        case 'ArrowRight': move(-1,0); break; // up-right
-        case 'ArrowLeft': move(1,0); break; // down-left
-        case 'ArrowDown': move(1,1); break; // down-right
+        case 'ArrowUp': move(-1,-1); break;
+        case 'ArrowRight': move(-1,0); break;
+        case 'ArrowLeft': move(1,0); break;
+        case 'ArrowDown': move(1,1); break;
       }
     });
 
-    draw();
+    startLevel();
+    setInterval(() => {
+      if(lives > 0){
+        enemyMove();
+        draw();
+        if(enemy.row === qbert.row && enemy.col === qbert.col){
+          loseLife();
+        }
+      }
+    }, 800);
   </script>
   <script>
     fetch('sidebar.html')


### PR DESCRIPTION
## Summary
- expand playfield to seven rows and resize canvas
- add levels, lives and floating platforms that reset each level
- introduce an enemy that chases the player
- create custom SVGs for qbert, the enemy, and floating platforms

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6884ed2a85f4833188c678a0b407aadd