### PR TITLE
Fix behind-plane building artifacts in Neon Flight

### DIFF
--- a/neon-flight.html
+++ b/neon-flight.html
@@ -128,7 +128,7 @@
           running = false;
           document.getElementById('message').textContent = 'Crash! Press Space';
         }
-        if(back <= -FOV){
+        if(back <= 0){
           buildings.splice(i, 1);
         }
       }
@@ -176,7 +176,9 @@
       ctx.clearRect(0,0,canvas.width,canvas.height);
       ctx.strokeStyle = '#0f0';
       ctx.lineWidth = 2;
-      for(const b of buildings) drawBuilding(b);
+      for(const b of buildings){
+        if(b.z + b.depth/2 >= 0) drawBuilding(b);
+      }
     }
 
     function loop(){


### PR DESCRIPTION
## Summary
- clean up building removal when a building is fully behind the player
- skip rendering buildings once they're behind the plane

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884f400d6e883319fcebef787c91169