### PR TITLE
Reduce building count for easier Neon Flight

### DIFF
--- a/neon-flight.html
+++ b/neon-flight.html
@@ -97,7 +97,7 @@
       distance = 0;
       running = true;
       document.getElementById('message').textContent = '';
-      for(let i=0;i<20;i++) spawnBuilding();
+        for(let i=0;i<10;i++) spawnBuilding();
     }
 
     function spawnBuilding(){
@@ -133,7 +133,7 @@
           buildings.splice(i, 1);
         }
       }
-      while(buildings.length < 20) spawnBuilding();
+        while(buildings.length < 10) spawnBuilding();
       distance += plane.speed;
       document.getElementById('info').textContent = `Distance: ${Math.floor(distance)}`;
     }


### PR DESCRIPTION
## Summary
- make Neon Flight more playable by halving the initial and ongoing building count

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6884fa3339208331a1cbae7e212295e8