### PR TITLE
Add platform friction and categorize Block Balance as in progress

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -87,6 +87,10 @@
     });
     World.add(world, platform);
 
+    // Track platform movement for friction
+    let lastPlatformX = platform.position.x;
+    const blocksOnPlatform = new Set();
+
     let moveLeft = false;
     let moveRight = false;
     const moveSpeed = 7;
@@ -99,6 +103,26 @@
       if (e.key === 'ArrowRight' || e.key === 'd') moveRight = false;
     });
 
+    Events.on(engine, 'collisionStart', event => {
+      for (const pair of event.pairs) {
+        if (pair.bodyA === platform && pair.bodyB.label === 'block') {
+          blocksOnPlatform.add(pair.bodyB);
+        } else if (pair.bodyB === platform && pair.bodyA.label === 'block') {
+          blocksOnPlatform.add(pair.bodyA);
+        }
+      }
+    });
+
+    Events.on(engine, 'collisionEnd', event => {
+      for (const pair of event.pairs) {
+        if (pair.bodyA === platform && pair.bodyB.label === 'block') {
+          blocksOnPlatform.delete(pair.bodyB);
+        } else if (pair.bodyB === platform && pair.bodyA.label === 'block') {
+          blocksOnPlatform.delete(pair.bodyA);
+        }
+      }
+    });
+
     Events.on(engine, 'beforeUpdate', () => {
       if (moveLeft && platform.position.x - platformWidth/2 > 0) {
         Body.translate(platform, { x: -moveSpeed, y: 0 });
@@ -106,6 +130,13 @@
       if (moveRight && platform.position.x + platformWidth/2 < 800) {
         Body.translate(platform, { x: moveSpeed, y: 0 });
       }
+
+      // Apply simple friction so blocks move with the platform
+      const dx = platform.position.x - lastPlatformX;
+      blocksOnPlatform.forEach(block => {
+        Body.translate(block, { x: dx * 0.9, y: 0 });
+      });
+      lastPlatformX = platform.position.x;
     });
 
     const blocks = [];

--- a/sidebar.html
+++ b/sidebar.html
@@ -4,7 +4,6 @@
   <ul>
     <li><a href="asteroids.html">Asteroids</a></li>
     <li><a href="drop-game.html">Drop Game</a></li>
-    <li><a href="balance.html">Block Balance</a></li>
     <li><a href="flappy.html">Flappy</a></li>
     <li><a href="missile-command.html">Missile Command</a></li>
     <li><a href="neon-flight.html">Neon Flight</a></li>
@@ -17,6 +16,7 @@
   <h3>In Work</h3>
   <ul>
     <li><a href="boxing.html">Boxing</a></li>
+    <li><a href="balance.html">Block Balance</a></li>
     <li><a href="burger.html">Burger Builder</a></li>
     <li><a href="joust.html">Joust</a></li>
     <li><a href="pacman.html">Pac-Man</a></li>


### PR DESCRIPTION
## Summary
- Move Block Balance from the Ready to Play list to the In Work list in the sidebar
- Simulate friction on the platform so resting blocks slide along with it in Block Balance

## Testing
- `node -v`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ebb042b88331b46def7326137e1f