### PR TITLE
Double player missile explosion radius in Missile Command

### DIFF
--- a/missile-command.html
+++ b/missile-command.html
@@ -158,7 +158,7 @@
         const dy = m.ty - m.y;
         const dist = Math.hypot(dx, dy);
         if (dist < playerSpeed) {
-          explosions.push({ x: m.tx, y: m.ty, r: 0, max: 40, hold: 0.25 });
+          explosions.push({ x: m.tx, y: m.ty, r: 0, max: 80, hold: 0.25 });
           playerMissiles.splice(i, 1);
         } else {
           m.x += dx / dist * playerSpeed;


### PR DESCRIPTION
## Summary
- Increase player's missile explosion size in Missile Command from radius 40 to 80 for larger impact area.

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689f8af8682c8331b998172ebb880620