### PR TITLE
Slow Block Balance spawn rate

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -220,7 +220,7 @@
 
     const spawnInterval = setInterval(() => {
       if (!gameOver) spawnBlock();
-    }, 2000);
+    }, 4000);
 
     let gameOver = false;
     Events.on(engine, 'afterUpdate', () => {


### PR DESCRIPTION
## Summary
- Slow Block Balance block spawn interval to half the original frequency

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f8e37bb8c833189638031b91bd877