### PR TITLE
Reduce gravity in balance game

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -79,7 +79,7 @@
     const { Engine, Render, Runner, Bodies, World, Body, Events } = Matter;
     const engine = Engine.create();
     const world = engine.world;
-    world.gravity.y = 0.25;
+    world.gravity.y = 0.125;
     const canvas = document.getElementById('world');
     const render = Render.create({
       canvas: canvas,


### PR DESCRIPTION
## Summary
- Slow block fall in Balance game by halving gravity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f8fb8ac288331818157b8fed4804c