### PR TITLE
Reorient boxing game to first-person perspective

### DIFF
--- a/boxing.html
+++ b/boxing.html
@@ -79,10 +79,10 @@
     const ctx = canvas.getContext('2d');
 
     const ring = {
-      fl: { x: canvas.width * 0.18, y: canvas.height - 110 },
-      fr: { x: canvas.width * 0.82, y: canvas.height - 110 },
-      bl: { x: canvas.width * 0.32, y: canvas.height - 320 },
-      br: { x: canvas.width * 0.68, y: canvas.height - 320 }
+      fl: { x: canvas.width * 0.12, y: canvas.height - 60 },
+      fr: { x: canvas.width * 0.88, y: canvas.height - 60 },
+      bl: { x: canvas.width * 0.36, y: canvas.height - 430 },
+      br: { x: canvas.width * 0.64, y: canvas.height - 430 }
     };
 
     const crowd = Array.from({ length: 120 }, (_, i) => ({
@@ -730,30 +730,28 @@
     }
 
     function getPlayerHandPosition(hand) {
-      const baseX = canvas.width / 2 + player.x * 90;
-      const baseY = canvas.height - 140;
+      const dodgeOffset = player.dodge.active ? Math.sin(player.dodge.progress * Math.PI) * 110 * player.dodge.dir : 0;
+      const baseX = canvas.width / 2 + player.x * 110 + dodgeOffset;
       const attack = player.attacks[hand];
-      let x = baseX + (hand === 'left' ? -70 : 70);
-      let y = canvas.height - 80;
-      let size = 18;
+      let x = baseX + (hand === 'left' ? -150 : 150);
+      let y = canvas.height - 180;
+      let size = 22;
       if (attack && attack.active) {
         const def = attack.def;
         const t = clamp(attack.progress, 0, 1);
         const extendPhase = t < 0.5 ? easeOutCubic(t / 0.5) : easeInCubic(1 - (t - 0.5) / 0.5);
         const reach = def.reach * extendPhase;
-        x += def.lateral * reach;
-        y -= reach;
+        x += def.lateral * reach * 0.7;
+        y -= reach * 1.1;
         if (def.arc) {
-          x += def.arc.x * Math.sin(Math.PI * t);
-          y += def.arc.y * Math.sin(Math.PI * t);
+          x += def.arc.x * 0.8 * Math.sin(Math.PI * t);
+          y += def.arc.y * 0.6 * Math.sin(Math.PI * t);
         }
-        size += 4 * Math.sin(t * Math.PI);
+        size += 6 * Math.sin(t * Math.PI);
       }
       if (player.blocking && (!attack || !attack.active)) {
-        y -= 70 * player.guard;
-      }
-      if (player.dodge.active) {
-        x += Math.sin(player.dodge.progress * Math.PI) * 80 * player.dodge.dir;
+        y -= 120 * player.guard;
+        x += (hand === 'left' ? 50 : -50) * player.guard;
       }
       return { x, y, size };
     }
@@ -767,7 +765,7 @@
       const slump = opp.state === 'stunned' ? Math.sin((1 - Math.max(0, opp.timer) / 2600) * Math.PI) * 20 : 0;
       return {
         x: canvas.width / 2 + dodgeOffset,
-        y: canvas.height / 2 - 90 + slump
+        y: canvas.height / 2 - 26 + slump
       };
     }
     function hexToRgba(hex, alpha) {
@@ -889,8 +887,9 @@
     function drawRing() {
       const { fl, fr, bl, br } = ring;
       const mat = ctx.createLinearGradient(bl.x, bl.y, bl.x, fl.y);
-      mat.addColorStop(0, '#1a2440');
-      mat.addColorStop(1, '#0b0f1c');
+      mat.addColorStop(0, '#121a30');
+      mat.addColorStop(0.35, '#15223f');
+      mat.addColorStop(1, '#070b16');
       ctx.fillStyle = mat;
       ctx.beginPath();
       ctx.moveTo(fl.x, fl.y);
@@ -899,20 +898,59 @@
       ctx.lineTo(fr.x, fr.y);
       ctx.closePath();
       ctx.fill();
-      ctx.strokeStyle = 'rgba(255,255,255,0.12)';
+      ctx.strokeStyle = 'rgba(255,255,255,0.16)';
       ctx.lineWidth = 3;
       ctx.stroke();
 
-      ctx.fillStyle = 'rgba(0,0,0,0.55)';
+      ctx.save();
       ctx.beginPath();
-      ctx.ellipse(canvas.width / 2, canvas.height - 80, 220, 40, 0, 0, Math.PI * 2);
+      ctx.moveTo(fl.x, fl.y);
+      ctx.lineTo(bl.x, bl.y);
+      ctx.lineTo(br.x, br.y);
+      ctx.lineTo(fr.x, fr.y);
+      ctx.closePath();
+      ctx.clip();
+
+      ctx.strokeStyle = 'rgba(120,170,255,0.18)';
+      ctx.lineWidth = 2;
+      const depthSteps = 6;
+      for (let i = 1; i < depthSteps; i++) {
+        const t = i / depthSteps;
+        const startX = fl.x + (fr.x - fl.x) * t;
+        const startY = fl.y + (fr.y - fl.y) * t;
+        const endX = bl.x + (br.x - bl.x) * t;
+        const endY = bl.y + (br.y - bl.y) * t;
+        ctx.beginPath();
+        ctx.moveTo(startX, startY);
+        ctx.lineTo(endX, endY);
+        ctx.stroke();
+      }
+
+      ctx.strokeStyle = 'rgba(120,170,255,0.12)';
+      const widthSteps = 5;
+      for (let i = 1; i < widthSteps; i++) {
+        const t = i / widthSteps;
+        const startX = fl.x + (bl.x - fl.x) * t;
+        const startY = fl.y + (bl.y - fl.y) * t;
+        const endX = fr.x + (br.x - fr.x) * t;
+        const endY = fr.y + (br.y - fr.y) * t;
+        ctx.beginPath();
+        ctx.moveTo(startX, startY);
+        ctx.lineTo(endX, endY);
+        ctx.stroke();
+      }
+      ctx.restore();
+
+      ctx.fillStyle = 'rgba(0,0,0,0.6)';
+      ctx.beginPath();
+      ctx.ellipse(canvas.width / 2, canvas.height - 36, 280, 76, 0, 0, Math.PI * 2);
       ctx.fill();
 
       const ropeColors = ['#ff3760', '#ffffff', '#11b9ff'];
       for (let i = 1; i <= 3; i++) {
-        const h = i * 12;
+        const h = i * 14;
         ctx.strokeStyle = ropeColors[i - 1];
-        ctx.lineWidth = 3;
+        ctx.lineWidth = 4;
         ctx.beginPath();
         ctx.moveTo(bl.x, bl.y - h);
         ctx.lineTo(br.x, br.y - h);
@@ -926,7 +964,7 @@
 
       ctx.fillStyle = '#2d3b60';
       [fl, fr, bl, br].forEach(corner => {
-        ctx.fillRect(corner.x - 6, corner.y - 40, 12, 40);
+        ctx.fillRect(corner.x - 7, corner.y - 54, 14, 54);
       });
     }
 
@@ -934,9 +972,10 @@
       const opp = game.opponent;
       if (!opp) return;
       const head = getOpponentHead();
-      const baseX = head.x;
-      const baseY = head.y + 70;
-      const slump = opp.state === 'stunned' ? 24 : 0;
+      const forwardLean = opp.attack && opp.attack.phase === 'swing' ? Math.sin(clamp(opp.attack.progress, 0, 1) * Math.PI) * 18 : 0;
+      const baseX = head.x + forwardLean * 0.35;
+      const baseY = head.y + 120;
+      const slump = opp.state === 'stunned' ? 36 : 0;
 
       if (opp.attack && opp.attack.phase === 'telegraph') {
         ctx.save();
@@ -948,164 +987,224 @@
         ctx.restore();
       }
 
-      const torsoGrad = ctx.createLinearGradient(baseX, head.y - 60, baseX, baseY + 140);
-      torsoGrad.addColorStop(0, hexToRgba(opp.color, 0.9));
-      torsoGrad.addColorStop(0.55, hexToRgba(opp.secondary, 0.9));
-      torsoGrad.addColorStop(1, 'rgba(10,12,20,0.95)');
+      ctx.save();
+      ctx.shadowColor = hexToRgba(opp.secondary, 0.25);
+      ctx.shadowBlur = 40;
+      const torsoGrad = ctx.createLinearGradient(baseX, head.y - 40, baseX, baseY + 220);
+      torsoGrad.addColorStop(0, hexToRgba(opp.color, 0.95));
+      torsoGrad.addColorStop(0.55, hexToRgba(opp.secondary, 0.92));
+      torsoGrad.addColorStop(1, 'rgba(8,12,22,0.98)');
       ctx.fillStyle = torsoGrad;
       ctx.beginPath();
-      ctx.ellipse(baseX, baseY + 30 + slump, 68, 100 + slump * 0.6, 0, 0, Math.PI * 2);
+      ctx.ellipse(baseX, baseY + 80 + slump * 0.4, 110, 190 + slump * 0.8, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+
+      ctx.fillStyle = hexToRgba(opp.secondary, 0.4);
+      ctx.beginPath();
+      ctx.ellipse(baseX, head.y + 60, 160, 90, 0, 0, Math.PI);
       ctx.fill();
 
       ctx.fillStyle = hexToRgba(opp.color, 0.95);
       ctx.beginPath();
-      ctx.arc(head.x, head.y, 34, 0, Math.PI * 2);
+      ctx.arc(head.x, head.y, 46, 0, Math.PI * 2);
       ctx.fill();
 
-      ctx.fillStyle = 'rgba(10,16,26,0.8)';
-      ctx.fillRect(head.x - 18, head.y - 10, 14, 6);
-      ctx.fillRect(head.x + 4, head.y - 10, 14, 6);
-      ctx.strokeStyle = 'rgba(18,24,34,0.8)';
-      ctx.lineWidth = 3;
+      ctx.fillStyle = 'rgba(10,16,26,0.78)';
+      ctx.fillRect(head.x - 24, head.y - 12, 18, 8);
+      ctx.fillRect(head.x + 6, head.y - 12, 18, 8);
+      ctx.strokeStyle = 'rgba(18,24,34,0.82)';
+      ctx.lineWidth = 4;
       ctx.beginPath();
-      ctx.arc(head.x, head.y + 10, 16, 0, Math.PI);
+      ctx.arc(head.x, head.y + 16, 22, 0, Math.PI);
       ctx.stroke();
 
-      ctx.fillStyle = hexToRgba(opp.secondary, 0.8);
-      ctx.fillRect(baseX - 70, baseY + 10 + slump, 140, 24);
-      ctx.fillStyle = hexToRgba(opp.color, 0.7);
-      ctx.fillRect(baseX - 60, baseY + 10 + slump, 120, 26);
+      ctx.fillStyle = hexToRgba(opp.secondary, 0.85);
+      ctx.fillRect(baseX - 110, baseY + 40 + slump * 0.6, 220, 34);
+      ctx.fillStyle = hexToRgba(opp.color, 0.78);
+      ctx.fillRect(baseX - 96, baseY + 36 + slump * 0.6, 192, 38);
 
       drawOpponentArm('left', head, baseX, baseY, slump);
       drawOpponentArm('right', head, baseX, baseY, slump);
 
-      ctx.strokeStyle = hexToRgba(opp.color, 0.8);
-      ctx.lineWidth = 10;
+      ctx.strokeStyle = hexToRgba(opp.color, 0.72);
+      ctx.lineWidth = 12;
       ctx.beginPath();
-      ctx.moveTo(baseX - 26, baseY + 90 + slump);
-      ctx.lineTo(baseX - 40, baseY + 160 + slump * 0.3);
-      ctx.moveTo(baseX + 26, baseY + 90 + slump);
-      ctx.lineTo(baseX + 40, baseY + 160 + slump * 0.3);
+      ctx.moveTo(baseX - 36, baseY + 160 + slump * 0.4);
+      ctx.lineTo(baseX - 30, baseY + 260 + slump * 0.3);
+      ctx.moveTo(baseX + 36, baseY + 160 + slump * 0.4);
+      ctx.lineTo(baseX + 30, baseY + 260 + slump * 0.3);
       ctx.stroke();
     }
 
     function drawOpponentArm(hand, head, baseX, baseY, slump) {
       const opp = game.opponent;
       const dir = hand === 'left' ? -1 : 1;
-      const shoulderX = baseX + dir * 36;
-      const shoulderY = baseY - 8 + slump * 0.4;
-      let gloveX = shoulderX;
-      let gloveY = shoulderY + 60;
-      let size = 16;
+      const shoulderX = baseX + dir * 72;
+      const shoulderY = baseY + 10 + slump * 0.35;
+      let gloveX = baseX + dir * 140;
+      let gloveY = baseY + 100;
+      let size = 24;
       const attack = opp.attack;
       const attacking = attack && opp.state === 'attack' && (attack.hand === hand || attack.hand === 'both');
 
       if (opp.blockTimer > 0) {
-        gloveX = head.x + dir * 26;
-        gloveY = head.y + 30;
-        size = 18;
+        gloveX = head.x + dir * 44;
+        gloveY = head.y + 42;
+        size = 28;
       } else if (attacking && attack.phase === 'swing') {
         const t = clamp(attack.progress, 0, 1);
         const extendPhase = t < 0.5 ? easeOutCubic(t / 0.5) : easeInCubic(1 - (t - 0.5) / 0.5);
         const reach = attack.reach * extendPhase;
-        gloveX = baseX + dir * 32;
-        gloveY = baseY + 20 + reach;
+        gloveX = baseX + dir * (90 + reach * 0.25);
+        gloveY = baseY + 80 + reach * 0.85;
         if (attack.key === 'hook') {
-          gloveX += dir * 50 * Math.sin(t * Math.PI);
-          gloveY += reach * 0.3;
+          gloveX += dir * 80 * Math.sin(t * Math.PI);
+          gloveY += reach * 0.35;
         } else if (attack.key === 'cross') {
-          gloveX += dir * 18 * Math.sin(t * Math.PI * 0.5);
+          gloveX += dir * 34 * Math.sin(t * Math.PI * 0.5);
         } else if (attack.flurry) {
-          gloveX += dir * 30 * Math.sin(t * Math.PI * 3);
-          gloveY += reach * 0.5;
+          gloveX += dir * 46 * Math.sin(t * Math.PI * 3);
+          gloveY += reach * 0.55;
         }
-        size = 18 + 4 * Math.sin(t * Math.PI);
+        size = 26 + 6 * Math.sin(t * Math.PI);
       } else if (opp.state === 'stunned') {
-        gloveY += 30;
+        gloveY += 46;
       }
 
-      ctx.strokeStyle = hexToRgba(opp.secondary, 0.85);
-      ctx.lineWidth = 9;
+      ctx.strokeStyle = hexToRgba(opp.secondary, 0.88);
+      ctx.lineWidth = 14;
       ctx.beginPath();
       ctx.moveTo(shoulderX, shoulderY);
       ctx.lineTo(gloveX, gloveY);
       ctx.stroke();
 
-      ctx.fillStyle = hexToRgba(opp.color, attacking ? 0.95 : 0.85);
+      ctx.fillStyle = hexToRgba(opp.color, attacking ? 0.97 : 0.9);
       ctx.beginPath();
       ctx.arc(gloveX, gloveY, size, 0, Math.PI * 2);
       ctx.fill();
+      ctx.strokeStyle = hexToRgba(opp.secondary, 0.5);
+      ctx.lineWidth = 4;
+      ctx.stroke();
     }
     function drawPlayer() {
-      const dodgeOffset = player.dodge.active ? Math.sin(player.dodge.progress * Math.PI) * 80 * player.dodge.dir : 0;
-      const baseX = canvas.width / 2 + player.x * 90 + dodgeOffset;
-      const baseY = canvas.height - 160;
+      const dodgeOffset = player.dodge.active ? Math.sin(player.dodge.progress * Math.PI) * 110 * player.dodge.dir : 0;
+      const baseX = canvas.width / 2 + player.x * 110 + dodgeOffset;
+      const torsoTop = canvas.height - 360;
+      const shoulderY = canvas.height - 240;
+      const waistY = canvas.height - 110;
+      const span = 260;
 
-      const torsoGrad = ctx.createLinearGradient(baseX, baseY - 80, baseX, baseY + 180);
-      torsoGrad.addColorStop(0, '#1cb2ff');
-      torsoGrad.addColorStop(0.6, '#0f4fa0');
-      torsoGrad.addColorStop(1, '#031631');
-      ctx.fillStyle = torsoGrad;
-      ctx.beginPath();
-      ctx.ellipse(baseX, baseY + 80, 70, 110, 0, 0, Math.PI * 2);
-      ctx.fill();
+      const buildSilhouettePath = () => {
+        ctx.beginPath();
+        ctx.moveTo(baseX - span, canvas.height + 12);
+        ctx.lineTo(baseX - span * 0.78, waistY + 32);
+        ctx.quadraticCurveTo(baseX - span * 0.55, shoulderY + 16, baseX - span * 0.32, torsoTop + 86);
+        ctx.quadraticCurveTo(baseX, torsoTop, baseX + span * 0.32, torsoTop + 86);
+        ctx.quadraticCurveTo(baseX + span * 0.55, shoulderY + 16, baseX + span * 0.78, waistY + 32);
+        ctx.lineTo(baseX + span, canvas.height + 12);
+        ctx.closePath();
+      };
 
-      ctx.fillStyle = '#9bd3ff';
-      ctx.beginPath();
-      ctx.arc(baseX, baseY, 30, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.fillStyle = '#0b1c2f';
-      ctx.fillRect(baseX - 20, baseY - 6, 40, 12);
+      buildSilhouettePath();
+      ctx.save();
+      ctx.clip();
+      const gradient = ctx.createLinearGradient(baseX, torsoTop, baseX, canvas.height + 40);
+      gradient.addColorStop(0, 'rgba(60,140,255,0.32)');
+      gradient.addColorStop(0.55, 'rgba(28,80,160,0.18)');
+      gradient.addColorStop(1, 'rgba(6,18,36,0.06)');
+      ctx.fillStyle = gradient;
+      ctx.fillRect(baseX - span, torsoTop, span * 2, canvas.height - torsoTop + 48);
 
-      ctx.fillStyle = '#132437';
-      ctx.fillRect(baseX - 60, baseY + 80, 120, 40);
-      ctx.fillStyle = '#1f3f64';
-      ctx.fillRect(baseX - 50, baseY + 80, 100, 42);
+      const gridRows = 6;
+      ctx.strokeStyle = 'rgba(130,210,255,0.24)';
+      ctx.lineWidth = 1.6;
+      for (let i = 1; i < gridRows; i++) {
+        const t = i / gridRows;
+        const y = torsoTop + (canvas.height - torsoTop) * t;
+        ctx.beginPath();
+        ctx.moveTo(baseX - span + span * 0.28 * t, y);
+        ctx.lineTo(baseX + span - span * 0.28 * t, y);
+        ctx.stroke();
+      }
 
-      ctx.strokeStyle = '#1f3f64';
-      ctx.lineWidth = 10;
-      ctx.beginPath();
-      ctx.moveTo(baseX - 25, baseY + 120);
-      ctx.lineTo(baseX - 35, canvas.height - 30);
-      ctx.moveTo(baseX + 25, baseY + 120);
-      ctx.lineTo(baseX + 35, canvas.height - 30);
+      ctx.strokeStyle = 'rgba(130,210,255,0.18)';
+      const gridCols = 7;
+      for (let i = 1; i < gridCols; i++) {
+        const t = i / gridCols;
+        const bottomX = baseX - span + span * 2 * t;
+        const topX = baseX - span * 0.35 + span * 0.7 * t;
+        ctx.beginPath();
+        ctx.moveTo(bottomX, canvas.height + 16);
+        ctx.lineTo(topX, torsoTop + 24);
+        ctx.stroke();
+      }
+      ctx.restore();
+
+      buildSilhouettePath();
+      ctx.strokeStyle = 'rgba(150,230,255,0.55)';
+      ctx.lineWidth = 3;
       ctx.stroke();
 
+      ctx.strokeStyle = 'rgba(190,245,255,0.38)';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(baseX - span * 0.4, torsoTop + 70);
+      ctx.quadraticCurveTo(baseX, torsoTop + 26, baseX + span * 0.4, torsoTop + 70);
+      ctx.stroke();
+
+      ctx.save();
+      ctx.globalCompositeOperation = 'screen';
       ['left', 'right'].forEach(hand => {
         const glove = getPlayerHandPosition(hand);
-        const startX = baseX + (hand === 'left' ? -50 : 50);
-        const startY = baseY + 20;
-        ctx.strokeStyle = hand === 'left' ? '#1bb0ff' : '#ff6d9f';
-        ctx.lineWidth = 10;
+        const anchorX = baseX + (hand === 'left' ? -150 : 150);
+        const anchorY = canvas.height - 180;
+        const curveControlX = baseX + (hand === 'left' ? -70 : 70);
+        const lineColor = hand === 'left' ? 'rgba(120,220,255,0.38)' : 'rgba(255,150,220,0.38)';
+        const glowColor = hand === 'left' ? 'rgba(150,240,255,0.55)' : 'rgba(255,190,240,0.55)';
+        ctx.strokeStyle = lineColor;
+        ctx.lineWidth = 9;
         ctx.beginPath();
-        ctx.moveTo(startX, startY);
-        ctx.lineTo(glove.x, glove.y);
+        ctx.moveTo(anchorX, anchorY);
+        ctx.quadraticCurveTo(curveControlX, canvas.height - 280, glove.x, glove.y);
         ctx.stroke();
-        ctx.fillStyle = hand === 'left' ? '#46d1ff' : '#ff88c6';
+
+        ctx.fillStyle = lineColor;
         ctx.beginPath();
-        ctx.arc(glove.x, glove.y, glove.size, 0, Math.PI * 2);
+        ctx.arc(glove.x, glove.y, glove.size + 6, 0, Math.PI * 2);
         ctx.fill();
+        ctx.strokeStyle = glowColor;
+        ctx.lineWidth = 2.5;
+        ctx.stroke();
       });
+      ctx.restore();
 
       if (player.blocking) {
-        const shieldAlpha = 0.3 + player.guard * 0.5;
-        ctx.fillStyle = `rgba(120,200,255,${shieldAlpha})`;
+        const shieldAlpha = 0.25 + player.guard * 0.4;
+        ctx.save();
+        ctx.globalCompositeOperation = 'screen';
+        ctx.strokeStyle = `rgba(140,220,255,${shieldAlpha})`;
+        ctx.lineWidth = 12;
         ctx.beginPath();
-        ctx.moveTo(baseX - 70, baseY - 20);
-        ctx.quadraticCurveTo(baseX, baseY - 60, baseX + 70, baseY - 20);
-        ctx.lineTo(baseX + 70, baseY + 80);
-        ctx.quadraticCurveTo(baseX, baseY + 120, baseX - 70, baseY + 80);
-        ctx.closePath();
-        ctx.fill();
+        ctx.arc(baseX, canvas.height - 260, 210, Math.PI * 0.12, Math.PI - Math.PI * 0.12, false);
+        ctx.stroke();
+        ctx.strokeStyle = `rgba(220,255,255,${shieldAlpha * 0.6})`;
+        ctx.lineWidth = 5;
+        ctx.beginPath();
+        ctx.arc(baseX, canvas.height - 250, 150, Math.PI * 0.18, Math.PI - Math.PI * 0.18, false);
+        ctx.stroke();
+        ctx.restore();
       }
 
       if (player.hype >= 100) {
+        const pulse = 0.22 + Math.sin(performance.now() * 0.006) * 0.08;
         ctx.save();
         ctx.globalCompositeOperation = 'lighter';
-        ctx.fillStyle = 'rgba(255,218,102,0.18)';
+        ctx.strokeStyle = `rgba(255,218,102,${pulse})`;
+        ctx.lineWidth = 9;
         ctx.beginPath();
-        ctx.ellipse(baseX, baseY + 40, 130, 70, 0, 0, Math.PI * 2);
-        ctx.fill();
+        ctx.arc(baseX, canvas.height - 220, 240, Math.PI * 0.08, Math.PI - Math.PI * 0.08, false);
+        ctx.stroke();
         ctx.restore();
       }
     }


### PR DESCRIPTION
## Summary
- reshape the ring perspective and floor grid so the match reads from a first-person angle
- enlarge and reposition the opponent, including new arm posing and shading that fill more of the frame
- replace the player model with a translucent grid silhouette and transparent gloves for an over-the-shoulder view

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ddbaefabb48331b791a54c01092495