### PR TITLE
Revamp Qbert remix with new visuals and enemies

### DIFF
--- a/qbert.html
+++ b/qbert.html
@@ -2,48 +2,91 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Qbert Clone</title>
+  <title>Qbert Remix</title>
   <style>
+    :root {
+      color-scheme: dark;
+    }
     body {
       margin: 0;
       display: flex;
       min-height: 100vh;
       overflow: hidden;
-      background: linear-gradient(135deg,#222 0%,#444 100%);
-      font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-      color: #fff;
+      background: radial-gradient(circle at 20% 20%, #4b1fff 0%, transparent 40%),
+                  radial-gradient(circle at 80% 10%, #ff4f6d 0%, transparent 45%),
+                  radial-gradient(circle at 50% 80%, #00f0ff 0%, transparent 55%),
+                  #050512;
+      font-family: "Rajdhani", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+      color: #f4f8ff;
+      letter-spacing: 0.03em;
     }
     #sidebar {
       width: 220px;
-      background: rgba(0,0,0,0.7);
-      padding: 20px;
-      box-shadow: 2px 0 8px rgba(0,0,0,0.2);
+      background: rgba(4, 12, 45, 0.78);
+      padding: 24px 20px;
+      backdrop-filter: blur(6px);
+      box-shadow: 0 0 30px rgba(46, 142, 255, 0.25);
+      border-right: 1px solid rgba(82, 120, 255, 0.35);
     }
-    #sidebar ul { list-style:none; padding:0; }
+    #sidebar ul { list-style:none; padding:0; margin:0; }
     #sidebar li { margin:15px 0; }
-    #sidebar a { color:#fff; text-decoration:none; }
-    #sidebar a:hover{ color:#ffea00; }
+    #sidebar a {
+      color:#e7ecff;
+      text-decoration:none;
+      font-weight:600;
+      text-transform:uppercase;
+      font-size:13px;
+      letter-spacing:0.12em;
+      transition: color 0.2s ease, text-shadow 0.2s ease;
+    }
+    #sidebar a:hover{
+      color:#74fffd;
+      text-shadow:0 0 8px rgba(116,255,253,0.7);
+    }
     #game-container {
       flex:1;
       display:flex;
       flex-direction:column;
       align-items:center;
-      padding:20px;
+      padding:30px 20px;
+      position:relative;
+    }
+    h1 {
+      margin:12px 0 16px;
+      font-size:42px;
+      font-weight:700;
+      text-transform:uppercase;
+      letter-spacing:0.25em;
+      color:#ffeae0;
+      text-shadow:0 0 18px rgba(255,180,80,0.6);
     }
     canvas {
-      background:#000;
-      border:2px solid #fff;
-      border-radius:8px;
+      background: radial-gradient(circle at center, rgba(10, 18, 56, 0.85) 0%, rgba(5,5,18,0.96) 70%, rgba(0,0,0,0.95) 100%);
+      border:2px solid rgba(255,255,255,0.15);
+      border-radius:16px;
+      box-shadow:0 25px 55px rgba(0, 0, 0, 0.55);
     }
-    #info { margin-top:10px; font-size:20px; }
-    #message { margin-top:10px; font-size:24px; color:#ffeb3b; }
+    #info {
+      margin-top:18px;
+      font-size:20px;
+      text-transform:uppercase;
+      letter-spacing:0.18em;
+      color:#b2c6ff;
+    }
+    #message {
+      margin-top:12px;
+      font-size:24px;
+      color:#fdf763;
+      min-height:32px;
+      text-shadow:0 0 12px rgba(253,247,99,0.45);
+    }
   </style>
 </head>
 <body>
   <div id="sidebar-placeholder"></div>
   <div id="game-container">
-    <h1>Qbert Clone</h1>
-    <canvas id="gameCanvas" width="600" height="600"></canvas>
+    <h1>Hyper Qbert</h1>
+    <canvas id="gameCanvas" width="640" height="640"></canvas>
     <div id="info"></div>
     <div id="message"></div>
   </div>
@@ -51,46 +94,72 @@
     const canvas = document.getElementById('gameCanvas');
     const ctx = canvas.getContext('2d');
     const ROWS = 7;
-    const TILE = 50;
-    const START_X = canvas.width/2;
-    const START_Y = 60;
-    const COLORS = ['#2196f3','#ff9800','#4caf50','#e91e63','#9c27b0','#00bcd4','#ffc107'];
-
-    const qbertImg = new Image();
-    qbertImg.src = 'images/qbert.svg';
-    const enemyImg = new Image();
-    enemyImg.src = 'images/qbert_enemy.svg';
-    const platformImg = new Image();
-    platformImg.src = 'images/qbert_platform.svg';
+    const TILE = 58;
+    const START_X = canvas.width / 2;
+    const START_Y = 80;
+    const LEVEL_PALETTES = [
+      ['#00fbff','#00c0ff','#0078ff'],
+      ['#ffe066','#ff964f','#ff4f4f'],
+      ['#adff9b','#53f6d6','#27b6ff'],
+      ['#ff9dfa','#c774ff','#715bff'],
+      ['#ffef9d','#ffad66','#ff5f87']
+    ];
 
     let level = 1;
     let lives = 3;
-    let tiles;
-    let visited;
+    let tiles = [];
+    let visited = 0;
     const qbert = {row:0,col:0};
-    const enemy = {row:ROWS-1,col:ROWS-1};
     const leftPlatform = {side:'left',used:false,x:0,y:0,lifting:false,t:0};
     const rightPlatform = {side:'right',used:false,x:0,y:0,lifting:false,t:0};
-    let enemyTimer;
-    let errorRate = 0.3;
+    const enemies = [];
+    const spawnTimeouts = [];
+    const spawnIntervals = [];
     let falling = false;
-    let fallPos = {x:0, y:0};
-    let fallTimer;
+    const fallPos = {x:0,y:0};
+    let fallTimer = null;
 
     const JUMP_TIME = 300;
     const JUMP_HEIGHT = TILE * 0.6;
     const PLATFORM_TIME = 600;
+    const EXPLOSION_TIME = 600;
+
     let qbertJump = null;
-    let enemyJump = null;
     let qbertOnPlatform = false;
     let qbertPlatform = null;
-    const EXPLOSION_TIME = 600;
     let explosion = null;
     let started = false;
     let lastTime = 0;
 
     const infoEl = document.getElementById('info');
     const messageEl = document.getElementById('message');
+
+    const sliderPath = [];
+    for(let r=0; r<ROWS; r++) sliderPath.push({row:r, col:0});
+    for(let c=1; c<ROWS; c++) sliderPath.push({row:ROWS-1, col:c});
+    for(let r=ROWS-2; r>0; r--) sliderPath.push({row:r, col:r});
+
+    const particles = Array.from({length:90}, () => ({
+      x: Math.random()*canvas.width,
+      y: Math.random()*canvas.height,
+      r: Math.random()*1.4 + 0.6,
+      speed: Math.random()*0.3 + 0.1,
+      hue: Math.random()*360
+    }));
+
+    function roundedRectPath(context, x, y, width, height, radius){
+      context.beginPath();
+      context.moveTo(x + radius, y);
+      context.lineTo(x + width - radius, y);
+      context.quadraticCurveTo(x + width, y, x + width, y + radius);
+      context.lineTo(x + width, y + height - radius);
+      context.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+      context.lineTo(x + radius, y + height);
+      context.quadraticCurveTo(x, y + height, x, y + height - radius);
+      context.lineTo(x, y + radius);
+      context.quadraticCurveTo(x, y, x + radius, y);
+      context.closePath();
+    }
 
     function tilePos(r,c){
       const x = START_X - (r*TILE)/2 + c*TILE;
@@ -103,13 +172,13 @@
       return {x: base.x + (side==='left'? -TILE : TILE), y: base.y};
     }
 
-    function resetPlatform(p){
-      const pos = platformPos(p.side);
-      p.x = pos.x;
-      p.y = pos.y;
-      p.lifting = false;
-      p.t = 0;
-      p.used = false;
+    function resetPlatform(platform){
+      const pos = platformPos(platform.side);
+      platform.x = pos.x;
+      platform.y = pos.y;
+      platform.lifting = false;
+      platform.t = 0;
+      platform.used = false;
     }
 
     function visitTile(r,c){
@@ -127,72 +196,235 @@
       ctx.lineTo(x+TILE/2,y+TILE);
       ctx.lineTo(x,y+TILE/2);
       ctx.closePath();
-      const idx = Math.min(tiles[r][c], level);
-      ctx.fillStyle = COLORS[idx];
+      const palette = LEVEL_PALETTES[(level-1) % LEVEL_PALETTES.length];
+      const stage = Math.min(tiles[r][c], palette.length-1);
+      const gradient = ctx.createLinearGradient(x, y, x+TILE, y+TILE);
+      gradient.addColorStop(0, palette[stage]);
+      gradient.addColorStop(0.6, palette[Math.max(stage-1,0)] || palette[0]);
+      gradient.addColorStop(1, '#060c1f');
+      ctx.fillStyle = gradient;
+      ctx.shadowColor = palette[stage];
+      ctx.shadowBlur = 18;
       ctx.fill();
-      ctx.strokeStyle = '#555';
+      ctx.shadowBlur = 0;
+      ctx.strokeStyle = 'rgba(14, 34, 68, 0.6)';
+      ctx.lineWidth = 2;
       ctx.stroke();
     }
 
     function drawPlatforms(){
-      [leftPlatform,rightPlatform].forEach(p=>{
-        if(!p.used || p.lifting || qbertPlatform===p){
-          ctx.drawImage(platformImg,p.x,p.y,TILE,TILE*0.6);
+      [leftPlatform, rightPlatform].forEach(platform => {
+        if(!platform.used || platform.lifting || qbertPlatform === platform){
+          const grd = ctx.createLinearGradient(platform.x, platform.y, platform.x+TILE, platform.y+TILE*0.6);
+          grd.addColorStop(0, 'rgba(255,255,255,0.85)');
+          grd.addColorStop(1, 'rgba(80,190,255,0.55)');
+          ctx.fillStyle = grd;
+          roundedRectPath(ctx, platform.x, platform.y, TILE, TILE*0.6, 8);
+          ctx.fill();
+          ctx.strokeStyle = 'rgba(10, 120, 210, 0.65)';
+          ctx.lineWidth = 2;
+          ctx.stroke();
+          ctx.lineWidth = 1;
         }
       });
     }
 
+    function drawQbertSprite(x,y){
+      const bodyGradient = ctx.createRadialGradient(x+12, y+12, 4, x+16, y+16, 20);
+      bodyGradient.addColorStop(0, '#ffeaa7');
+      bodyGradient.addColorStop(1, '#ff8c42');
+      ctx.fillStyle = bodyGradient;
+      ctx.beginPath();
+      ctx.ellipse(x+16, y+18, 18, 20, 0, 0, Math.PI*2);
+      ctx.fill();
+      ctx.fillStyle = '#402310';
+      ctx.beginPath();
+      ctx.moveTo(x+8, y+32);
+      ctx.lineTo(x+24, y+32);
+      ctx.lineTo(x+16, y+46);
+      ctx.closePath();
+      ctx.fill();
+      ctx.fillStyle = '#fff';
+      ctx.beginPath();
+      ctx.ellipse(x+12, y+14, 6, 7, 0, 0, Math.PI*2);
+      ctx.ellipse(x+22, y+14, 6, 7, 0, 0, Math.PI*2);
+      ctx.fill();
+      ctx.fillStyle = '#1f1f1f';
+      ctx.beginPath();
+      ctx.arc(x+12, y+14, 2.2, 0, Math.PI*2);
+      ctx.arc(x+22, y+14, 2.2, 0, Math.PI*2);
+      ctx.fill();
+      ctx.strokeStyle = 'rgba(255,220,120,0.7)';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(x+16, y+4);
+      ctx.quadraticCurveTo(x+2, y+0, x+6, y+20);
+      ctx.stroke();
+      ctx.lineWidth = 1;
+    }
+
+    function drawEnemySprite(enemy, x, y){
+      ctx.save();
+      if(enemy.type === 'hopper'){
+        const grd = ctx.createLinearGradient(x, y, x+32, y+32);
+        grd.addColorStop(0, '#6d8bff');
+        grd.addColorStop(1, '#2a34ff');
+        ctx.fillStyle = grd;
+        roundedRectPath(ctx, x+4, y+4, 24, 28, 10);
+        ctx.fill();
+        ctx.fillStyle = '#091134';
+        ctx.fillRect(x+10, y+20, 4, 12);
+        ctx.fillRect(x+18, y+20, 4, 12);
+        ctx.fillStyle = '#fff';
+        ctx.beginPath();
+        ctx.arc(x+12, y+14, 4, 0, Math.PI*2);
+        ctx.arc(x+20, y+14, 4, 0, Math.PI*2);
+        ctx.fill();
+        ctx.fillStyle = '#00113c';
+        ctx.beginPath();
+        ctx.arc(x+12, y+14, 2.4, 0, Math.PI*2);
+        ctx.arc(x+20, y+14, 2.4, 0, Math.PI*2);
+        ctx.fill();
+      } else if(enemy.type === 'slider'){
+        const angle = performance.now()/400;
+        ctx.translate(x+16, y+16);
+        ctx.rotate(angle);
+        const sliderGradient = ctx.createLinearGradient(-16, -16, 16, 16);
+        sliderGradient.addColorStop(0, '#ff6fd8');
+        sliderGradient.addColorStop(1, '#ffef6f');
+        ctx.fillStyle = sliderGradient;
+        ctx.beginPath();
+        ctx.moveTo(0, -18);
+        ctx.lineTo(16, -2);
+        ctx.lineTo(10, 20);
+        ctx.lineTo(-10, 20);
+        ctx.lineTo(-16, -2);
+        ctx.closePath();
+        ctx.fill();
+        ctx.restore();
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+        ctx.strokeStyle = 'rgba(255,239,111,0.6)';
+        ctx.lineWidth = 3;
+        ctx.beginPath();
+        ctx.arc(x+16, y+16, 20, 0, Math.PI*2);
+        ctx.stroke();
+      } else if(enemy.type === 'phantom'){
+        const pulse = 0.45 + 0.55*Math.sin(performance.now()/600 + enemy.phase);
+        ctx.globalAlpha = 0.65 + 0.3*pulse;
+        const phantomGradient = ctx.createRadialGradient(x+16, y+16, 4, x+16, y+16, 18);
+        phantomGradient.addColorStop(0, `rgba(170, 120, 255, ${0.9*pulse})`);
+        phantomGradient.addColorStop(0.7, `rgba(120, 60, 255, ${0.6*pulse})`);
+        phantomGradient.addColorStop(1, 'rgba(30, 10, 80, 0.05)');
+        ctx.fillStyle = phantomGradient;
+        ctx.beginPath();
+        ctx.ellipse(x+16, y+16, 18, 20, 0, 0, Math.PI*2);
+        ctx.fill();
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = '#fff';
+        ctx.beginPath();
+        ctx.arc(x+12, y+16, 3, 0, Math.PI*2);
+        ctx.arc(x+20, y+16, 3, 0, Math.PI*2);
+        ctx.fill();
+        ctx.fillStyle = '#261055';
+        ctx.beginPath();
+        ctx.arc(x+12, y+16, 1.6, 0, Math.PI*2);
+        ctx.arc(x+20, y+16, 1.6, 0, Math.PI*2);
+        ctx.fill();
+      }
+      ctx.restore();
+    }
+
+    function drawParticles(){
+      ctx.save();
+      particles.forEach(p => {
+        ctx.fillStyle = `hsla(${p.hue}, 70%, 65%, 0.55)`;
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, p.r, 0, Math.PI*2);
+        ctx.fill();
+      });
+      ctx.restore();
+    }
+
     function draw(){
       ctx.clearRect(0,0,canvas.width,canvas.height);
-      let q;
+      const bgGradient = ctx.createRadialGradient(canvas.width/2, canvas.height/3, 40, canvas.width/2, canvas.height/2, canvas.height/1.1);
+      bgGradient.addColorStop(0, 'rgba(28, 46, 92, 0.9)');
+      bgGradient.addColorStop(0.4, 'rgba(15, 20, 46, 0.65)');
+      bgGradient.addColorStop(1, 'rgba(0,0,10,0.85)');
+      ctx.fillStyle = bgGradient;
+      ctx.fillRect(0,0,canvas.width,canvas.height);
+      drawParticles();
+
+      let qPos;
       if(qbertJump){
         const t = Math.min(qbertJump.t / JUMP_TIME, 1);
         const start = tilePos(qbertJump.start.row, qbertJump.start.col);
-        const end = qbertJump.platform ? {x:qbertJump.platform.x,y:qbertJump.platform.y} : tilePos(qbertJump.end.row,qbertJump.end.col);
-        q = {
+        const end = qbertJump.platform ? {x:qbertJump.platform.x, y:qbertJump.platform.y} : tilePos(qbertJump.end.row, qbertJump.end.col);
+        qPos = {
           x: start.x + (end.x - start.x) * t,
           y: start.y + (end.y - start.y) * t - Math.sin(t*Math.PI)*JUMP_HEIGHT
         };
       } else if(qbertOnPlatform && qbertPlatform){
-        q = {x:qbertPlatform.x, y:qbertPlatform.y};
+        qPos = {x:qbertPlatform.x, y:qbertPlatform.y};
       } else {
-        q = tilePos(qbert.row,qbert.col);
+        qPos = tilePos(qbert.row, qbert.col);
       }
 
       if(falling){
-        ctx.drawImage(qbertImg,fallPos.x,fallPos.y,32,32);
+        drawQbertSprite(fallPos.x, fallPos.y);
       }
 
-      for(let r=ROWS-1;r>=0;r--){
-        for(let c=0;c<=r;c++){
+      for(let r=ROWS-1; r>=0; r--){
+        for(let c=0; c<=r; c++){
           drawTile(r,c);
         }
       }
       drawPlatforms();
 
       if(!falling && !explosion){
-        ctx.drawImage(qbertImg,q.x+TILE/2-16,q.y+TILE/2-16,32,32);
+        drawQbertSprite(qPos.x + TILE/2 - 16, qPos.y + TILE/2 - 20);
+      }
 
-      }
-      let e;
-      if(enemyJump){
-        const t = Math.min(enemyJump.t / JUMP_TIME, 1);
-        const start = tilePos(enemyJump.start.row, enemyJump.start.col);
-        const end = tilePos(enemy.row, enemy.col);
-        e = {
-          x: start.x + (end.x - start.x) * t,
-          y: start.y + (end.y - start.y) * t - Math.sin(t*Math.PI)*JUMP_HEIGHT
-        };
-      } else {
-        e = tilePos(enemy.row,enemy.col);
-      }
-      ctx.drawImage(enemyImg,e.x+TILE/2-16,e.y+TILE/2-16,32,32);
+      enemies.forEach(enemy => {
+        if(enemy.type === 'phantom' && !enemy.jump && enemy.visible === false){
+          return;
+        }
+        let pos;
+        if(enemy.jump){
+          const t = Math.min(enemy.jump.t / enemy.jump.duration, 1);
+          const start = tilePos(enemy.jump.start.row, enemy.jump.start.col);
+          const end = tilePos(enemy.row, enemy.col);
+          const arcScale = enemy.jump.arcScale ?? 1;
+          const lift = enemy.jump.style === 'warp' ? 0 : Math.sin(t*Math.PI) * JUMP_HEIGHT * arcScale;
+          pos = {
+            x: start.x + (end.x - start.x) * t,
+            y: start.y + (end.y - start.y) * t - lift
+          };
+          if(enemy.jump.style === 'warp'){
+            const radius = 22 * (1 - Math.abs(0.5 - t) * 2);
+            ctx.save();
+            ctx.globalAlpha = 0.2;
+            ctx.strokeStyle = 'rgba(180,150,255,0.4)';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            ctx.arc(pos.x+TILE/2, pos.y+TILE/2, radius, 0, Math.PI*2);
+            ctx.stroke();
+            ctx.restore();
+          }
+        } else {
+          pos = tilePos(enemy.row, enemy.col);
+        }
+        drawEnemySprite(enemy, pos.x + TILE/2 - 16, pos.y + TILE/2 - 20);
+      });
+
       if(explosion){
         ctx.fillStyle = `rgba(255,165,0,${1 - explosion.t/EXPLOSION_TIME})`;
         ctx.beginPath();
         ctx.arc(explosion.x, explosion.y, explosion.r, 0, Math.PI*2);
         ctx.fill();
       }
+
       infoEl.textContent = `Level: ${level} Lives: ${lives} - ${visited}/${ROWS*(ROWS+1)/2}`;
     }
 
@@ -200,7 +432,7 @@
       if(visited === ROWS*(ROWS+1)/2){
         messageEl.textContent = `Level ${level} complete!`;
         level++;
-        setTimeout(startLevel, 1000);
+        setTimeout(startLevel, 1200);
       }
     }
 
@@ -210,67 +442,61 @@
       explosion = {x: pos.x + TILE/2, y: pos.y + TILE/2, t: 0, r: 0};
     }
 
+    function resetEnemiesPositions(){
+      enemies.forEach(enemy => {
+        enemy.jump = null;
+        if(enemy.type === 'hopper'){
+          enemy.row = ROWS-1;
+          enemy.col = ROWS-1;
+          enemy.timer = 0;
+        } else if(enemy.type === 'slider'){
+          enemy.pathIndex = 0;
+          enemy.row = sliderPath[0].row;
+          enemy.col = sliderPath[0].col;
+          enemy.timer = 0;
+        } else if(enemy.type === 'phantom'){
+          enemy.row = 2;
+          enemy.col = 1;
+          enemy.visible = false;
+          enemy.timer = enemy.moveDelay;
+        }
+      });
+    }
+
     function loseLife(){
       lives--;
       if(lives <= 0){
         messageEl.textContent = 'Game Over';
       } else {
-        qbert.row=0; qbert.col=0;
-        enemy.row=ROWS-1; enemy.col=ROWS-1;
+        qbert.row = 0; qbert.col = 0;
+        qbertJump = null;
+        qbertOnPlatform = false;
+        qbertPlatform = null;
+        resetEnemiesPositions();
+        visitTile(0,0);
       }
       draw();
     }
 
-   function enemyMove(){
-      if(falling || enemyJump) return;
-      let bestR = enemy.row;
-      let bestC = enemy.col;
-      let bestDist = Infinity;
-      const target = tilePos(qbert.row,qbert.col);
-      let options = [
-        [enemy.row+1, enemy.col],
-        [enemy.row+1, enemy.col+1],
-        [enemy.row-1, enemy.col],
-        [enemy.row-1, enemy.col-1]
-      ];
-      options = options.filter(([nr,nc]) => nr>=0 && nr<ROWS && nc>=0 && nc<=nr);
-      if(options.length === 0) return;
-      if(Math.random() < errorRate){
-        const [nr,nc] = options[Math.floor(Math.random()*options.length)];
-        enemyJump = {start:{row:enemy.row,col:enemy.col},end:{row:nr,col:nc},t:0};
-        enemy.row = nr;
-        enemy.col = nc;
-        return;
-      }
-      for(const [nr,nc] of options){
-        const pos = tilePos(nr,nc);
-        const d = (pos.x-target.x)**2 + (pos.y-target.y)**2;
-        if(d < bestDist){ bestDist=d; bestR=nr; bestC=nc; }
-      }
-      enemyJump = {start:{row:enemy.row,col:enemy.col},end:{row:bestR,col:bestC},t:0};
-      enemy.row = bestR;
-      enemy.col = bestC;
-   }
-
-    function usePlatform(p){
+    function usePlatform(platform){
       qbertOnPlatform = true;
-      qbertPlatform = p;
-      p.lifting = true;
-      p.t = 0;
+      qbertPlatform = platform;
+      platform.lifting = true;
+      platform.t = 0;
       const dest = tilePos(0,0);
-      p.start = {x:p.x, y:p.y};
-      p.end = {x:dest.x, y:dest.y};
+      platform.start = {x:platform.x, y:platform.y};
+      platform.end = {x:dest.x, y:dest.y};
     }
 
     function fallOff(dr,dc){
       falling = true;
       const target = tilePos(qbert.row + dr, qbert.col + dc);
       fallPos.x = target.x + TILE/2 - 16;
-      fallPos.y = target.y + TILE/2 - 16;
+      fallPos.y = target.y + TILE/2 - 20;
       if(fallTimer) clearInterval(fallTimer);
       draw();
       fallTimer = setInterval(() => {
-        fallPos.y += 8;
+        fallPos.y += 10;
         draw();
         if(fallPos.y > canvas.height){
           clearInterval(fallTimer);
@@ -280,59 +506,10 @@
       }, 30);
     }
 
-    function update(dt){
-      if(explosion){
-        explosion.t += dt;
-        explosion.r = 30 * (explosion.t / EXPLOSION_TIME);
-        if(explosion.t >= EXPLOSION_TIME){
-          explosion = null;
-          loseLife();
-        }
-        return;
-      }
-      if(qbertJump){
-        qbertJump.t += dt;
-        if(qbertJump.t >= JUMP_TIME){
-          if(qbertJump.platform){
-            usePlatform(qbertJump.platform);
-          } else {
-            visitTile(qbert.row,qbert.col);
-            if(enemy.row === qbert.row && enemy.col === qbert.col) startExplosion();
-            checkWin();
-          }
-          qbertJump = null;
-        }
-      }
-      if(enemyJump){
-        enemyJump.t += dt;
-        if(enemyJump.t >= JUMP_TIME){
-          enemyJump = null;
-          if(enemy.row === qbert.row && enemy.col === qbert.col && !qbertJump && !falling && !qbertOnPlatform) startExplosion();
-        }
-      }
-      [leftPlatform,rightPlatform].forEach(p=>{
-        if(p.lifting){
-          p.t += dt;
-          const t = Math.min(p.t/PLATFORM_TIME,1);
-          p.x = p.start.x + (p.end.x - p.start.x)*t;
-          p.y = p.start.y + (p.end.y - p.start.y)*t;
-          if(t>=1){
-            p.lifting = false;
-            p.used = true;
-            qbertOnPlatform = false;
-            qbertPlatform = null;
-            qbert.row = 0; qbert.col = 0;
-            visitTile(0,0);
-            checkWin();
-          }
-        }
-      });
-    }
-
     function move(dr,dc){
       if(lives <= 0 || falling || qbertJump || qbertOnPlatform || explosion) return;
-      let nr = qbert.row + dr;
-      let nc = qbert.col + dc;
+      const nr = qbert.row + dr;
+      const nc = qbert.col + dc;
       if(nr<0 || nr>=ROWS || nc<0 || nc>nr){
         if(qbert.row === ROWS-2 && dr === -1){
           if(dc === -1 && qbert.col === 0 && !leftPlatform.used){
@@ -348,34 +525,266 @@
         return;
       }
       qbertJump = {start:{row:qbert.row,col:qbert.col}, end:{row:nr,col:nc}, t:0};
-      qbert.row = nr; qbert.col = nc;
+      qbert.row = nr;
+      qbert.col = nc;
+    }
+
+    function spawnEnemy(type, announce=true){
+      const enemy = createEnemy(type);
+      enemies.push(enemy);
+      if(enemy.type === 'phantom'){
+        enemy.timer = enemy.moveDelay;
+      }
+      if(announce){
+        switch(type){
+          case 'hopper':
+            messageEl.textContent = 'Vibro Hopper inbound!';
+            break;
+          case 'slider':
+            messageEl.textContent = 'Neon Slider is racing the rails!';
+            break;
+          case 'phantom':
+            messageEl.textContent = 'Phase Wisp slips into reality!';
+            break;
+        }
+        setTimeout(() => {
+          if(messageEl.textContent && !messageEl.textContent.includes('complete')){
+            messageEl.textContent = '';
+          }
+        }, 1800);
+      }
+    }
+
+    function createEnemy(type){
+      if(type === 'slider'){
+        return {
+          type,
+          row: sliderPath[0].row,
+          col: sliderPath[0].col,
+          pathIndex: 0,
+          moveDelay: Math.max(440, 980 - level*70),
+          timer: 0,
+          arc: 0.45
+        };
+      }
+      if(type === 'phantom'){
+        return {
+          type,
+          row: 2,
+          col: 1,
+          moveDelay: Math.max(1500, 3200 - level*120),
+          timer: 0,
+          phase: Math.random()*Math.PI*2,
+          visible: false,
+          arc: 0.1
+        };
+      }
+      return {
+        type: 'hopper',
+        row: ROWS-1,
+        col: ROWS-1,
+        moveDelay: Math.max(320, 900 - level*70),
+        timer: 0,
+        arc: 1,
+        errorRate: Math.max(0.05, 0.3 - (level-1)*0.035)
+      };
+    }
+
+    function enemyAct(enemy){
+      if(enemy.type === 'hopper'){
+        hopperMove(enemy);
+      } else if(enemy.type === 'slider'){
+        sliderMove(enemy);
+      } else if(enemy.type === 'phantom'){
+        phantomMove(enemy);
+      }
+    }
+
+    function hopperMove(enemy){
+      if(falling || qbertOnPlatform || explosion) return;
+      const target = tilePos(qbert.row,qbert.col);
+      let options = [
+        [enemy.row+1, enemy.col],
+        [enemy.row+1, enemy.col+1],
+        [enemy.row-1, enemy.col],
+        [enemy.row-1, enemy.col-1]
+      ].filter(([nr,nc]) => nr>=0 && nr<ROWS && nc>=0 && nc<=nr);
+      if(options.length === 0) return;
+      if(Math.random() < enemy.errorRate){
+        const [nr,nc] = options[Math.floor(Math.random()*options.length)];
+        beginEnemyJump(enemy, {row:nr,col:nc});
+        enemy.row = nr;
+        enemy.col = nc;
+        return;
+      }
+      let best = options[0];
+      let bestDist = Infinity;
+      options.forEach(([nr,nc]) => {
+        const pos = tilePos(nr,nc);
+        const dist = (pos.x-target.x)**2 + (pos.y-target.y)**2;
+        if(dist < bestDist){
+          bestDist = dist;
+          best = [nr,nc];
+        }
+      });
+      beginEnemyJump(enemy, {row:best[0], col:best[1]});
+      enemy.row = best[0];
+      enemy.col = best[1];
+    }
+
+    function sliderMove(enemy){
+      if(sliderPath.length === 0) return;
+      enemy.pathIndex = (enemy.pathIndex + 1) % sliderPath.length;
+      const target = sliderPath[enemy.pathIndex];
+      beginEnemyJump(enemy, {row:target.row, col:target.col}, {arcScale:0.4});
+      enemy.row = target.row;
+      enemy.col = target.col;
+    }
+
+    function phantomMove(enemy){
+      const candidates = [];
+      const radius = 2 + Math.floor(level/2);
+      for(let r=0;r<ROWS;r++){
+        for(let c=0;c<=r;c++){
+          const dist = Math.abs(r - qbert.row) + Math.abs(c - qbert.col);
+          if(dist <= radius){
+            const occupied = enemies.some(e => e !== enemy && e.row === r && e.col === c);
+            if(!occupied) candidates.push({row:r,col:c});
+          }
+        }
+      }
+      if(candidates.length === 0){
+        candidates.push({row:Math.floor(Math.random()*ROWS), col:0});
+      }
+      const choice = candidates[Math.floor(Math.random()*candidates.length)];
+      beginEnemyJump(enemy, choice, {duration:520, style:'warp', arcScale:0.15});
+      enemy.row = choice.row;
+      enemy.col = choice.col;
+    }
+
+    function beginEnemyJump(enemy, destination, options={}){
+      enemy.jump = {
+        start: {row: enemy.row, col: enemy.col},
+        end: destination,
+        t: 0,
+        duration: options.duration || JUMP_TIME,
+        style: options.style || 'jump',
+        arcScale: options.arcScale ?? enemy.arc ?? 1
+      };
+    }
+
+    function update(dt){
+      if(explosion){
+        explosion.t += dt;
+        explosion.r = 30 * (explosion.t / EXPLOSION_TIME);
+        if(explosion.t >= EXPLOSION_TIME){
+          explosion = null;
+          loseLife();
+        }
+        return;
+      }
+
+      if(qbertJump){
+        qbertJump.t += dt;
+        if(qbertJump.t >= JUMP_TIME){
+          if(qbertJump.platform){
+            usePlatform(qbertJump.platform);
+          } else {
+            visitTile(qbert.row, qbert.col);
+            if(enemies.some(e => e.row === qbert.row && e.col === qbert.col)){
+              startExplosion();
+            }
+            checkWin();
+          }
+          qbertJump = null;
+        }
+      }
+
+      enemies.forEach(enemy => {
+        if(enemy.jump){
+          enemy.jump.t += dt;
+          if(enemy.jump.t >= enemy.jump.duration){
+            enemy.jump = null;
+            if(enemy.type === 'phantom'){
+              enemy.visible = true;
+            }
+            if(enemy.row === qbert.row && enemy.col === qbert.col && !qbertJump && !falling && !qbertOnPlatform){
+              startExplosion();
+            }
+          }
+        } else {
+          enemy.timer += dt;
+          if(enemy.timer >= enemy.moveDelay){
+            enemy.timer = 0;
+            enemyAct(enemy);
+          }
+        }
+      });
+
+      particles.forEach(p => {
+        p.y += p.speed;
+        p.x += Math.sin((p.y+p.hue)/140)*0.6;
+        if(p.y > canvas.height) p.y = -5;
+        if(p.x > canvas.width) p.x = -5;
+        if(p.x < -5) p.x = canvas.width + 5;
+      });
+
+      [leftPlatform, rightPlatform].forEach(platform => {
+        if(platform.lifting){
+          platform.t += dt;
+          const t = Math.min(platform.t/PLATFORM_TIME,1);
+          platform.x = platform.start.x + (platform.end.x - platform.start.x)*t;
+          platform.y = platform.start.y + (platform.end.y - platform.start.y)*t;
+          if(t >= 1){
+            platform.lifting = false;
+            platform.used = true;
+            qbertOnPlatform = false;
+            qbertPlatform = null;
+            qbert.row = 0; qbert.col = 0;
+            visitTile(0,0);
+            checkWin();
+          }
+        }
+      });
     }
 
     function startLevel(){
       tiles = [];
       for(let r=0;r<ROWS;r++){
-        tiles[r]=[];
-        for(let c=0;c<=r;c++) tiles[r][c]=0;
+        tiles[r] = [];
+        for(let c=0;c<=r;c++){
+          tiles[r][c] = 0;
+        }
       }
       visited = 0;
       resetPlatform(leftPlatform);
       resetPlatform(rightPlatform);
       qbert.row = 0; qbert.col = 0;
-      enemy.row = ROWS-1; enemy.col = ROWS-1;
-      qbertJump = null; enemyJump = null; qbertOnPlatform=false; qbertPlatform=null;
+      qbertJump = null;
+      qbertOnPlatform = false;
+      qbertPlatform = null;
       falling = false;
       explosion = null;
       if(fallTimer) clearInterval(fallTimer);
+      spawnTimeouts.forEach(clearTimeout);
+      spawnTimeouts.length = 0;
+      spawnIntervals.forEach(clearInterval);
+      spawnIntervals.length = 0;
+      enemies.length = 0;
       visitTile(0,0);
       messageEl.textContent = '';
-      const interval = Math.max(300, 1000 - (level-1)*100);
-      errorRate = Math.max(0, 0.30 - 0.05*(level-1));
-      if(enemyTimer) clearInterval(enemyTimer);
-      enemyTimer = setInterval(() => {
-        if(lives > 0){
-          enemyMove();
-        }
-      }, interval);
+
+      spawnEnemy('hopper', false);
+      if(level >= 2){
+        spawnTimeouts.push(setTimeout(() => spawnEnemy('slider'), 4500));
+      }
+      if(level >= 3){
+        spawnTimeouts.push(setTimeout(() => spawnEnemy('phantom'), 9000));
+      }
+      if(level >= 4){
+        spawnIntervals.push(setInterval(() => spawnEnemy('hopper', false), Math.max(9000, 16000 - level*800)));
+      }
+
       if(!started){
         started = true;
         lastTime = performance.now();


### PR DESCRIPTION
## Summary
- refresh the Qbert page with a neon UI, larger canvas, and animated backdrop
- redraw Qbert and platforms procedurally on canvas and add particle effects for flair
- introduce new slider and phantom enemies that spawn over time alongside improved hopper AI

## Testing
- Manual testing in the browser

------
https://chatgpt.com/codex/tasks/task_e_68dfee8771d08331bccebd41fc00e6b1